### PR TITLE
feat: Add Asset Event Streaming WebSocket Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,32 @@ This gateway acts as a proxy between your web application and `tapd`, handling:
 - **Better error messages** - Meaningful errors instead of raw gRPC codes
 - **Request tracking** - UUID for each request aids debugging
 
+## Why Use This?
+
+If you're building a web app that needs Taproot Assets, you have three options:
+
+1. **Use tapd's gRPC API** - Requires gRPC-web, complex for browsers
+2. **Use tapd's REST API directly** - No CORS support, won't work from browsers  
+3. **Use this gateway** - Works immediately from any web app
+
+## Features
+
+### What Works Now
+- ✅ Complete REST API coverage for tapd
+- ✅ CORS support for web browsers
+- ✅ Automatic macaroon authentication
+- ✅ Request ID tracking
+- ✅ Basic rate limiting
+- ✅ Docker support
+- ✅ Health check endpoints
+
+### What's Missing
+- 🚧 WebSocket support for real-time events (in progress)
+- ❌ Response caching
+- ❌ Metrics/monitoring endpoints
+- ❌ Load balancing for multiple tapd instances
+- ❌ Advanced rate limiting (per endpoint/user)
+
 ## Quick Start
 
 ```bash
@@ -40,13 +66,40 @@ docker-compose up -d
 cargo run --release
 ```
 
-## Why Use This?
+## .env Configuration
 
-If you're building a web app that needs Taproot Assets, you have three options:
+```env
+# Required
+TAPROOT_ASSETS_HOST=127.0.0.1:8289
+TAPD_MACAROON_PATH=/path/to/tapd/admin.macaroon
+LND_MACAROON_PATH=/path/to/lnd/admin.macaroon
 
-1. **Use tapd's gRPC API** - Requires gRPC-web, complex for browsers
-2. **Use tapd's REST API directly** - No CORS support, won't work from browsers  
-3. **Use this gateway** - Works immediately from any web app
+# Security (use true in production)
+TLS_VERIFY=false
+
+# CORS - Add your app's URL
+CORS_ORIGINS=http://localhost:3000,http://localhost:5173
+
+# Optional
+SERVER_ADDRESS=127.0.0.1:8080
+REQUEST_TIMEOUT_SECS=30
+RATE_LIMIT_PER_MINUTE=100
+```
+
+## Architecture
+
+```
+Web App → REST Gateway → tapd gRPC/REST
+         ↓
+   [CORS Headers]
+   [Macaroon Auth]
+   [Rate Limiting]
+   [Error Handling]
+```
+
+The gateway forwards requests to tapd's REST API (port 8089) while adding the necessary headers and authentication that web browsers require.
+
+For complete API reference, see the [official Taproot Assets API documentation](https://lightning.engineering/api-docs/api/taproot-assets/).
 
 ## Usage Examples
 
@@ -242,30 +295,6 @@ REQUEST_TIMEOUT_SECS=30
 RATE_LIMIT_PER_MINUTE=100
 ```
 
-## Testing Requirements
-- Bitcoin Core with RPC enabled (for integration tests)
-- Set BITCOIN_RPC_USER and BITCOIN_RPC_PASS
-- LND & tapd running
-- Or use Polar for easier setup
-
-## Features
-
-### What Works Now
-- ✅ Complete REST API coverage for tapd
-- ✅ CORS support for web browsers
-- ✅ Automatic macaroon authentication
-- ✅ Request ID tracking
-- ✅ Basic rate limiting
-- ✅ Docker support
-- ✅ Health check endpoints
-
-### What's Missing
-- 🚧 WebSocket support for real-time events (in progress)
-- ❌ Response caching
-- ❌ Metrics/monitoring endpoints
-- ❌ Load balancing for multiple tapd instances
-- ❌ Advanced rate limiting (per endpoint/user)
-
 ## Development Setup
 
 1. **Install Polar** for local Lightning development
@@ -279,18 +308,11 @@ RATE_LIMIT_PER_MINUTE=100
 5. **Configure `.env`** with the paths
 6. **Run tests**: `cargo test`
 
-## Architecture
-
-```
-Web App → REST Gateway → tapd gRPC/REST
-         ↓
-   [CORS Headers]
-   [Macaroon Auth]
-   [Rate Limiting]
-   [Error Handling]
-```
-
-The gateway forwards requests to tapd's REST API (port 8089) while adding the necessary headers and authentication that web browsers require.
+## Testing Requirements
+- Bitcoin Core with RPC enabled (for integration tests)
+- Set BITCOIN_RPC_USER and BITCOIN_RPC_PASS
+- LND & tapd running
+- Or use Polar for easier setup
 
 ## Limitations
 

--- a/src/api/events.rs
+++ b/src/api/events.rs
@@ -200,27 +200,34 @@ pub async fn asset_send_events(
     }
 }
 
-async fn asset_mint_websocket_handler(
+#[instrument(skip(req, stream, ws_proxy_handler))]
+async fn generic_event_websocket_handler(
     req: HttpRequest,
     stream: web::Payload,
     ws_proxy_handler: web::Data<Arc<WebSocketProxyHandler>>,
+    event_type: &str,
 ) -> ActixResult<HttpResponse> {
-    info!("Handling WebSocket connection for asset mint events");
+    info!("Handling WebSocket connection for {} events", event_type);
 
     // Extract query parameters and forward them to the backend
     let query_string = req.query_string();
     let endpoint = if query_string.is_empty() {
-        "/v1/taproot-assets/events/asset-mint?method=POST".to_string()
+        format!("/v1/taproot-assets/events/{event_type}?method=POST")
     } else {
-        format!(
-            "/v1/taproot-assets/events/asset-mint?method=POST&{}",
-            query_string
-        )
+        format!("/v1/taproot-assets/events/{event_type}?method=POST&{query_string}")
     };
 
     ws_proxy_handler
         .handle_websocket(req, stream, &endpoint, false)
         .await
+}
+
+async fn asset_mint_websocket_handler(
+    req: HttpRequest,
+    stream: web::Payload,
+    ws_proxy_handler: web::Data<Arc<WebSocketProxyHandler>>,
+) -> ActixResult<HttpResponse> {
+    generic_event_websocket_handler(req, stream, ws_proxy_handler, "asset-mint").await
 }
 
 async fn asset_receive_websocket_handler(
@@ -228,22 +235,7 @@ async fn asset_receive_websocket_handler(
     stream: web::Payload,
     ws_proxy_handler: web::Data<Arc<WebSocketProxyHandler>>,
 ) -> ActixResult<HttpResponse> {
-    info!("Handling WebSocket connection for asset receive events");
-
-    // Extract query parameters and forward them to the backend
-    let query_string = req.query_string();
-    let endpoint = if query_string.is_empty() {
-        "/v1/taproot-assets/events/asset-receive?method=POST".to_string()
-    } else {
-        format!(
-            "/v1/taproot-assets/events/asset-receive?method=POST&{}",
-            query_string
-        )
-    };
-
-    ws_proxy_handler
-        .handle_websocket(req, stream, &endpoint, false)
-        .await
+    generic_event_websocket_handler(req, stream, ws_proxy_handler, "asset-receive").await
 }
 
 async fn asset_send_websocket_handler(
@@ -251,22 +243,7 @@ async fn asset_send_websocket_handler(
     stream: web::Payload,
     ws_proxy_handler: web::Data<Arc<WebSocketProxyHandler>>,
 ) -> ActixResult<HttpResponse> {
-    info!("Handling WebSocket connection for asset send events");
-
-    // Extract query parameters and forward them to the backend
-    let query_string = req.query_string();
-    let endpoint = if query_string.is_empty() {
-        "/v1/taproot-assets/events/asset-send?method=POST".to_string()
-    } else {
-        format!(
-            "/v1/taproot-assets/events/asset-send?method=POST&{}",
-            query_string
-        )
-    };
-
-    ws_proxy_handler
-        .handle_websocket(req, stream, &endpoint, false)
-        .await
+    generic_event_websocket_handler(req, stream, ws_proxy_handler, "asset-send").await
 }
 
 async fn set_debug_level_handler(
@@ -361,4 +338,167 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
                 .route(web::post().to(asset_send_handler))
                 .route(web::get().to(asset_send_websocket_handler)),
         );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_websocket_url_format_asset_mint() {
+        let base_url = "wss://localhost:8080";
+        let endpoint = "/v1/taproot-assets/events/asset-mint?method=POST";
+        let full_url = format!("{}{}", base_url, endpoint);
+
+        assert_eq!(
+            full_url,
+            "wss://localhost:8080/v1/taproot-assets/events/asset-mint?method=POST"
+        );
+        assert!(full_url.contains("method=POST"));
+        assert!(full_url.starts_with("wss://"));
+    }
+
+    #[test]
+    fn test_websocket_url_format_asset_receive() {
+        let base_url = "wss://localhost:8080";
+        let endpoint = "/v1/taproot-assets/events/asset-receive?method=POST";
+        let full_url = format!("{}{}", base_url, endpoint);
+
+        assert_eq!(
+            full_url,
+            "wss://localhost:8080/v1/taproot-assets/events/asset-receive?method=POST"
+        );
+        assert!(full_url.contains("method=POST"));
+        assert!(full_url.starts_with("wss://"));
+    }
+
+    #[test]
+    fn test_websocket_url_format_asset_send() {
+        let base_url = "wss://localhost:8080";
+        let endpoint = "/v1/taproot-assets/events/asset-send?method=POST";
+        let full_url = format!("{}{}", base_url, endpoint);
+
+        assert_eq!(
+            full_url,
+            "wss://localhost:8080/v1/taproot-assets/events/asset-send?method=POST"
+        );
+        assert!(full_url.contains("method=POST"));
+        assert!(full_url.starts_with("wss://"));
+    }
+
+    #[test]
+    fn test_websocket_query_parameter_forwarding() {
+        // Test query parameter handling for different event types
+
+        // Asset mint parameters
+        let mint_query = "short_response=true&method=POST";
+        assert!(mint_query.contains("method=POST"));
+        assert!(mint_query.contains("short_response=true"));
+
+        // Asset receive parameters
+        let receive_query = "filter_addr=addr123&start_timestamp=1234567890&method=POST";
+        assert!(receive_query.contains("method=POST"));
+        assert!(receive_query.contains("filter_addr=addr123"));
+        assert!(receive_query.contains("start_timestamp=1234567890"));
+
+        // Asset send parameters
+        let send_query = "filter_script_key=key123&filter_label=label456&method=POST";
+        assert!(send_query.contains("method=POST"));
+        assert!(send_query.contains("filter_script_key=key123"));
+        assert!(send_query.contains("filter_label=label456"));
+    }
+
+    #[test]
+    fn test_asset_mint_request_serialization() {
+        let request = AssetMintRequest {
+            short_response: true,
+        };
+
+        let serialized = serde_json::to_string(&request).unwrap();
+        assert!(serialized.contains("short_response"));
+        assert!(serialized.contains("true"));
+    }
+
+    #[test]
+    fn test_asset_receive_request_serialization() {
+        let request = AssetReceiveRequest {
+            filter_addr: Some("addr123".to_string()),
+            start_timestamp: Some("1234567890".to_string()),
+        };
+
+        let serialized = serde_json::to_string(&request).unwrap();
+        assert!(serialized.contains("filter_addr"));
+        assert!(serialized.contains("addr123"));
+        assert!(serialized.contains("start_timestamp"));
+        assert!(serialized.contains("1234567890"));
+    }
+
+    #[test]
+    fn test_asset_send_request_serialization() {
+        let request = AssetSendRequest {
+            filter_script_key: Some("key123".to_string()),
+            filter_label: Some("label456".to_string()),
+        };
+
+        let serialized = serde_json::to_string(&request).unwrap();
+        assert!(serialized.contains("filter_script_key"));
+        assert!(serialized.contains("key123"));
+        assert!(serialized.contains("filter_label"));
+        assert!(serialized.contains("label456"));
+    }
+
+    #[test]
+    fn test_event_schema_validation() {
+        // Validate that expected response fields match the documented schemas
+
+        // Asset mint event schema
+        let mint_event = serde_json::json!({
+            "timestamp": "1234567890",
+            "batch_state": "BATCH_STATE_BROADCAST",
+            "batch": {
+                "batch_key": "key123",
+                "batch_txid": "txid123"
+            },
+            "error": ""
+        });
+        assert!(mint_event.get("timestamp").is_some());
+        assert!(mint_event.get("batch_state").is_some());
+        assert!(mint_event.get("batch").is_some());
+
+        // Asset receive event schema
+        let receive_event = serde_json::json!({
+            "timestamp": "1234567890",
+            "address": {
+                "encoded": "addr123",
+                "asset_id": "asset123"
+            },
+            "outpoint": "outpoint123",
+            "status": "ADDR_EVENT_STATUS_TRANSACTION_CONFIRMED",
+            "confirmation_height": 100,
+            "error": ""
+        });
+        assert!(receive_event.get("timestamp").is_some());
+        assert!(receive_event.get("address").is_some());
+        assert!(receive_event.get("outpoint").is_some());
+        assert!(receive_event.get("status").is_some());
+
+        // Asset send event schema
+        let send_event = serde_json::json!({
+            "timestamp": "1234567890",
+            "send_state": "SEND_STATE_VIRTUAL_COMMIT_BROADCAST",
+            "parcel_type": "PARCEL_TYPE_SEND",
+            "addresses": [],
+            "virtual_packets": [],
+            "passive_virtual_packets": [],
+            "anchor_transaction": {},
+            "transfer": {},
+            "error": "",
+            "transfer_label": "label123",
+            "next_send_state": "SEND_STATE_COMPLETED"
+        });
+        assert!(send_event.get("timestamp").is_some());
+        assert!(send_event.get("send_state").is_some());
+        assert!(send_event.get("parcel_type").is_some());
+        assert!(send_event.get("addresses").is_some());
+    }
 }

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -1,10 +1,15 @@
-use actix_web::{test, App};
+use actix_web::{test, web, App};
+use std::sync::Arc;
 use std::time::Duration;
 use taproot_assets_rest_gateway::api::events::{
     AssetMintRequest, AssetReceiveRequest, AssetSendRequest,
 };
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::tests::setup::setup_without_assets;
+use taproot_assets_rest_gateway::types::{BaseUrl, MacaroonHex};
+use taproot_assets_rest_gateway::websocket::{
+    connection_manager::WebSocketConnectionManager, proxy_handler::WebSocketProxyHandler,
+};
 use tokio::time::timeout;
 
 #[actix_rt::test]
@@ -190,6 +195,294 @@ async fn test_event_endpoint_availability() {
         }
         Err(_) => {
             // Timeout is fine
+        }
+    }
+}
+
+#[actix_rt::test]
+async fn test_asset_mint_websocket_endpoint() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+
+    // Create WebSocket infrastructure
+    let connection_manager = Arc::new(WebSocketConnectionManager::new(
+        BaseUrl(base_url.get_ref().0.clone()),
+        MacaroonHex(macaroon_hex.get_ref().0.clone()),
+        false,
+    ));
+    let ws_proxy_handler = Arc::new(WebSocketProxyHandler::new(connection_manager));
+
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .app_data(web::Data::new(ws_proxy_handler))
+            .configure(configure),
+    )
+    .await;
+
+    // Test WebSocket endpoint with GET request (WebSocket upgrade)
+    let req = test::TestRequest::get()
+        .uri("/v1/taproot-assets/events/asset-mint")
+        .insert_header(("upgrade", "websocket"))
+        .insert_header(("connection", "upgrade"))
+        .insert_header(("sec-websocket-version", "13"))
+        .insert_header(("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ=="))
+        .to_request();
+
+    let result = timeout(Duration::from_secs(5), test::call_service(&app, req)).await;
+
+    match result {
+        Ok(resp) => {
+            // WebSocket endpoint exists and can be accessed
+            // In test environment, backend connection may fail, but endpoint should exist
+            assert_ne!(
+                resp.status(),
+                actix_web::http::StatusCode::NOT_FOUND,
+                "WebSocket endpoint not found"
+            );
+            assert_ne!(
+                resp.status(),
+                actix_web::http::StatusCode::METHOD_NOT_ALLOWED,
+                "WebSocket endpoint does not support GET method"
+            );
+        }
+        Err(_) => {
+            // Timeout is acceptable for WebSocket endpoints that wait for connections
+            println!("WebSocket asset mint endpoint timed out (acceptable for testing)");
+        }
+    }
+}
+
+#[actix_rt::test]
+async fn test_asset_receive_websocket_endpoint() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+
+    let connection_manager = Arc::new(WebSocketConnectionManager::new(
+        BaseUrl(base_url.get_ref().0.clone()),
+        MacaroonHex(macaroon_hex.get_ref().0.clone()),
+        false,
+    ));
+    let ws_proxy_handler = Arc::new(WebSocketProxyHandler::new(connection_manager));
+
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .app_data(web::Data::new(ws_proxy_handler))
+            .configure(configure),
+    )
+    .await;
+
+    // Test WebSocket endpoint with query parameters
+    let req = test::TestRequest::get()
+        .uri("/v1/taproot-assets/events/asset-receive?filter_addr=test_addr&start_timestamp=1234567890")
+        .insert_header(("upgrade", "websocket"))
+        .insert_header(("connection", "upgrade"))
+        .insert_header(("sec-websocket-version", "13"))
+        .insert_header(("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ=="))
+        .to_request();
+
+    let result = timeout(Duration::from_secs(5), test::call_service(&app, req)).await;
+
+    match result {
+        Ok(resp) => {
+            // WebSocket endpoint exists and can be accessed
+            // In test environment, backend connection may fail, but endpoint should exist
+            assert_ne!(
+                resp.status(),
+                actix_web::http::StatusCode::NOT_FOUND,
+                "WebSocket endpoint not found"
+            );
+            assert_ne!(
+                resp.status(),
+                actix_web::http::StatusCode::METHOD_NOT_ALLOWED,
+                "WebSocket endpoint does not support GET method"
+            );
+        }
+        Err(_) => {
+            println!("WebSocket asset receive endpoint timed out (acceptable for testing)");
+        }
+    }
+}
+
+#[actix_rt::test]
+async fn test_asset_send_websocket_endpoint() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+
+    let connection_manager = Arc::new(WebSocketConnectionManager::new(
+        BaseUrl(base_url.get_ref().0.clone()),
+        MacaroonHex(macaroon_hex.get_ref().0.clone()),
+        false,
+    ));
+    let ws_proxy_handler = Arc::new(WebSocketProxyHandler::new(connection_manager));
+
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .app_data(web::Data::new(ws_proxy_handler))
+            .configure(configure),
+    )
+    .await;
+
+    // Test WebSocket endpoint with filtering parameters
+    let req = test::TestRequest::get()
+        .uri("/v1/taproot-assets/events/asset-send?filter_script_key=key123&filter_label=label456")
+        .insert_header(("upgrade", "websocket"))
+        .insert_header(("connection", "upgrade"))
+        .insert_header(("sec-websocket-version", "13"))
+        .insert_header(("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ=="))
+        .to_request();
+
+    let result = timeout(Duration::from_secs(5), test::call_service(&app, req)).await;
+
+    match result {
+        Ok(resp) => {
+            // WebSocket endpoint exists and can be accessed
+            // In test environment, backend connection may fail, but endpoint should exist
+            assert_ne!(
+                resp.status(),
+                actix_web::http::StatusCode::NOT_FOUND,
+                "WebSocket endpoint not found"
+            );
+            assert_ne!(
+                resp.status(),
+                actix_web::http::StatusCode::METHOD_NOT_ALLOWED,
+                "WebSocket endpoint does not support GET method"
+            );
+        }
+        Err(_) => {
+            println!("WebSocket asset send endpoint timed out (acceptable for testing)");
+        }
+    }
+}
+
+#[actix_rt::test]
+async fn test_websocket_endpoint_availability() {
+    // Test that WebSocket endpoints are registered and accessible via GET requests
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+
+    let connection_manager = Arc::new(WebSocketConnectionManager::new(
+        BaseUrl(base_url.get_ref().0.clone()),
+        MacaroonHex(macaroon_hex.get_ref().0.clone()),
+        false,
+    ));
+    let ws_proxy_handler = Arc::new(WebSocketProxyHandler::new(connection_manager));
+
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .app_data(web::Data::new(ws_proxy_handler))
+            .configure(configure),
+    )
+    .await;
+
+    // Test all three WebSocket endpoints exist and don't return 404
+    let endpoints = vec![
+        "/v1/taproot-assets/events/asset-mint",
+        "/v1/taproot-assets/events/asset-receive",
+        "/v1/taproot-assets/events/asset-send",
+    ];
+
+    for endpoint in endpoints {
+        let req = test::TestRequest::get().uri(endpoint).to_request();
+
+        let result = timeout(Duration::from_millis(100), test::call_service(&app, req)).await;
+
+        match result {
+            Ok(resp) => {
+                assert_ne!(
+                    resp.status(),
+                    actix_web::http::StatusCode::NOT_FOUND,
+                    "WebSocket endpoint {} not found",
+                    endpoint
+                );
+                assert_ne!(
+                    resp.status(),
+                    actix_web::http::StatusCode::METHOD_NOT_ALLOWED,
+                    "WebSocket endpoint {} does not support GET method",
+                    endpoint
+                );
+            }
+            Err(_) => {
+                // Timeout is acceptable, endpoint exists but waiting for WebSocket upgrade
+                println!(
+                    "WebSocket endpoint {} exists but timed out (acceptable)",
+                    endpoint
+                );
+            }
+        }
+    }
+}
+
+#[actix_rt::test]
+async fn test_websocket_query_parameter_forwarding() {
+    // Test that query parameters are properly forwarded to the backend
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+
+    let connection_manager = Arc::new(WebSocketConnectionManager::new(
+        BaseUrl(base_url.get_ref().0.clone()),
+        MacaroonHex(macaroon_hex.get_ref().0.clone()),
+        false,
+    ));
+    let ws_proxy_handler = Arc::new(WebSocketProxyHandler::new(connection_manager));
+
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .app_data(web::Data::new(ws_proxy_handler))
+            .configure(configure),
+    )
+    .await;
+
+    // Test complex query parameter combinations
+    let test_cases = vec![
+        ("/v1/taproot-assets/events/asset-mint?short_response=true", "mint"),
+        ("/v1/taproot-assets/events/asset-receive?filter_addr=addr123&start_timestamp=1234567890", "receive"),
+        ("/v1/taproot-assets/events/asset-send?filter_script_key=key123&filter_label=test_label", "send"),
+    ];
+
+    for (uri, event_type) in test_cases {
+        let req = test::TestRequest::get()
+            .uri(uri)
+            .insert_header(("upgrade", "websocket"))
+            .insert_header(("connection", "upgrade"))
+            .insert_header(("sec-websocket-version", "13"))
+            .insert_header(("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ=="))
+            .to_request();
+
+        let result = timeout(Duration::from_millis(500), test::call_service(&app, req)).await;
+
+        match result {
+            Ok(resp) => {
+                // Should not return 404 (endpoint exists) or 400 (parameters properly parsed)
+                assert_ne!(
+                    resp.status(),
+                    actix_web::http::StatusCode::NOT_FOUND,
+                    "WebSocket {} endpoint with parameters not found",
+                    event_type
+                );
+                assert_ne!(
+                    resp.status(),
+                    actix_web::http::StatusCode::BAD_REQUEST,
+                    "WebSocket {} endpoint rejected parameters",
+                    event_type
+                );
+            }
+            Err(_) => {
+                // Timeout is acceptable for WebSocket endpoints
+                println!(
+                    "WebSocket {} endpoint with parameters timed out (acceptable)",
+                    event_type
+                );
+            }
         }
     }
 }

--- a/tests/setup_configuration.rs
+++ b/tests/setup_configuration.rs
@@ -273,10 +273,10 @@ async fn test_cors_configuration() {
 
 #[actix_rt::test]
 async fn test_tls_security_configuration() {
-    // Load .env first to get the actual TLS_VERIFY value
+    // Load .env to ensure all required environment variables are available
     dotenv::from_filename(".env").ok();
 
-    // Store the original value
+    // Store the original value before any modifications
     let original_tls_verify = std::env::var("TLS_VERIFY").ok();
 
     // Test with explicit true setting
@@ -293,6 +293,15 @@ async fn test_tls_security_configuration() {
     assert!(
         !config.tls_verify,
         "TLS verification should be disabled when set to false"
+    );
+
+    // Test default behavior (should default to true)
+
+    std::env::remove_var("TLS_VERIFY");
+    let config = Config::load().expect("Failed to load config");
+    assert!(
+        config.tls_verify,
+        "TLS verification should default to true when not set"
     );
 
     // Restore original value


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebSocket support for asset event subscriptions, allowing clients to subscribe to asset mint, receive, and send events in real-time using WebSocket connections on the same endpoints as existing HTTP subscriptions.
* **Bug Fixes**
  * Enhanced TLS configuration tests to verify default TLS verification behavior when environment variables are unset.
* **Documentation**
  * Reorganized and expanded README with clearer sections on usage, features, configuration, and architecture for improved user guidance.
* **Tests**
  * Added comprehensive tests for WebSocket event endpoints to verify availability, query parameter forwarding, and correct response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->