### PR TITLE
Switch BurnRequest to asset_specifier and validate it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "taproot-assets-rest-gateway"
-version = "0.0.1"
+version = "0.2.1"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/src/api/burn.rs
+++ b/src/api/burn.rs
@@ -1,4 +1,4 @@
-use super::handle_result;
+use super::{handle_result, validate_asset_id, validate_group_key};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpResponse};
@@ -12,6 +12,21 @@ pub struct AssetSpecifier {
     pub asset_id_str: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group_key_str: Option<String>,
+}
+
+impl AssetSpecifier {
+    fn validate(&self) -> Result<(), AppError> {
+        match (self.asset_id_str.as_deref(), self.group_key_str.as_deref()) {
+            (Some(_), Some(_)) => Err(AppError::InvalidInput(
+                "asset_specifier must set exactly one of asset_id_str or group_key_str".to_string(),
+            )),
+            (None, None) => Err(AppError::InvalidInput(
+                "asset_specifier must set either asset_id_str or group_key_str".to_string(),
+            )),
+            (Some(asset_id), None) => validate_asset_id(asset_id),
+            (None, Some(group_key)) => validate_group_key(group_key),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -29,7 +44,13 @@ pub async fn burn_assets(
     macaroon_hex: &str,
     request: BurnRequest,
 ) -> Result<serde_json::Value, AppError> {
-    info!("Burning assets");
+    request.asset_specifier.validate()?;
+    info!(
+        asset_id_str = ?request.asset_specifier.asset_id_str,
+        group_key_str = ?request.asset_specifier.group_key_str,
+        amount_to_burn = %request.amount_to_burn,
+        "Burning assets"
+    );
     let url = format!("{base_url}/v1/taproot-assets/burn");
     let response = client
         .post(&url)

--- a/src/api/burn.rs
+++ b/src/api/burn.rs
@@ -7,9 +7,16 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, instrument};
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct BurnRequest {
-    pub asset_id: String,
+pub struct AssetSpecifier {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_id_str: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_key_str: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BurnRequest {
+    pub asset_specifier: AssetSpecifier,
     pub amount_to_burn: String,
     pub confirmation_text: String,
     pub note: Option<String>,
@@ -22,7 +29,7 @@ pub async fn burn_assets(
     macaroon_hex: &str,
     request: BurnRequest,
 ) -> Result<serde_json::Value, AppError> {
-    info!("Burning assets for asset ID: {}", request.asset_id);
+    info!("Burning assets");
     let url = format!("{base_url}/v1/taproot-assets/burn");
     let response = client
         .post(&url)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -54,6 +54,33 @@ pub fn validate_path_param(value: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+const ASSET_ID_HEX_LEN: usize = 64;
+const GROUP_KEY_HEX_LENS: [usize; 2] = [64, 66];
+
+pub fn validate_asset_id(value: &str) -> Result<(), AppError> {
+    validate_hex_param(value)?;
+    if value.len() != ASSET_ID_HEX_LEN {
+        return Err(AppError::InvalidInput(format!(
+            "Invalid asset ID: expected {ASSET_ID_HEX_LEN} hex characters, got {}",
+            value.len()
+        )));
+    }
+    Ok(())
+}
+
+/// tapd accepts a group key as either a 32-byte x-only or a 33-byte
+/// compressed public key, so both hex lengths are valid.
+pub fn validate_group_key(value: &str) -> Result<(), AppError> {
+    validate_hex_param(value)?;
+    if !GROUP_KEY_HEX_LENS.contains(&value.len()) {
+        return Err(AppError::InvalidInput(format!(
+            "Invalid group key: expected 64 or 66 hex characters, got {}",
+            value.len()
+        )));
+    }
+    Ok(())
+}
+
 pub fn validate_integer_param(value: &str) -> Result<(), AppError> {
     if value.parse::<u64>().is_err() {
         return Err(AppError::InvalidInput(format!(

--- a/tests/burn.rs
+++ b/tests/burn.rs
@@ -2,7 +2,7 @@ use actix_web::{test, App};
 use serde_json::Value;
 use serial_test::serial;
 use std::time::Duration;
-use taproot_assets_rest_gateway::api::burn::BurnRequest;
+use taproot_assets_rest_gateway::api::burn::{AssetSpecifier, BurnRequest};
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup, setup_without_assets};
 use tokio::time::sleep;
@@ -158,8 +158,10 @@ async fn test_burn_assets_with_correct_confirmation() {
 
     let burn_amount = "10";
     let request = BurnRequest {
-        asset_id: asset_id.clone(),
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id.clone()),
+            group_key_str: None,
+        },
         amount_to_burn: burn_amount.to_string(),
         confirmation_text: "assets will be destroyed".to_string(),
         note: Some("Test burn operation".to_string()),
@@ -259,8 +261,10 @@ async fn test_burn_with_incorrect_confirmation() {
 
     // Test with incorrect confirmation text
     let request = BurnRequest {
-        asset_id: asset_id.clone(),
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id.clone()),
+            group_key_str: None,
+        },
         amount_to_burn: "10".to_string(), // Reduced amount
         confirmation_text: "incorrect text".to_string(),
         note: None,
@@ -309,8 +313,10 @@ async fn test_burn_with_metadata() {
 
     // Test burn with notes/metadata
     let request = BurnRequest {
-        asset_id: asset_id.clone(),
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id.clone()),
+            group_key_str: None,
+        },
         amount_to_burn: "5".to_string(), // Small amount
         confirmation_text: "assets will be destroyed".to_string(),
         note: Some("Burning assets for compliance reasons - Ticket #12345".to_string()),
@@ -430,8 +436,10 @@ async fn test_burn_edge_cases() {
 
     // Test with zero amount
     let request = BurnRequest {
-        asset_id: asset_id.clone(),
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id.clone()),
+            group_key_str: None,
+        },
         amount_to_burn: "0".to_string(),
         confirmation_text: "assets will be destroyed".to_string(),
         note: None,
@@ -453,8 +461,10 @@ async fn test_burn_edge_cases() {
 
     // Test with invalid amount format
     let request_invalid = BurnRequest {
-        asset_id: asset_id.clone(),
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id.clone()),
+            group_key_str: None,
+        },
         amount_to_burn: "invalid".to_string(),
         confirmation_text: "assets will be destroyed".to_string(),
         note: None,
@@ -497,8 +507,10 @@ async fn test_burn_response_structure() {
 
     // Perform a valid burn to check response structure
     let request = BurnRequest {
-        asset_id: asset_id.clone(),
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id.clone()),
+            group_key_str: None,
+        },
         amount_to_burn: "5".to_string(), // Small amount
         confirmation_text: "assets will be destroyed".to_string(),
         note: Some("Testing response structure".to_string()),
@@ -579,8 +591,10 @@ async fn test_burn_validation_messages() {
     let test_cases = vec![
         (
             BurnRequest {
-                asset_id: asset_id.clone(),
-                asset_id_str: None,
+                asset_specifier: AssetSpecifier {
+                    asset_id_str: Some(asset_id.clone()),
+                    group_key_str: None,
+                },
                 amount_to_burn: "0".to_string(),
                 confirmation_text: "assets will be destroyed".to_string(),
                 note: None,
@@ -589,8 +603,10 @@ async fn test_burn_validation_messages() {
         ),
         (
             BurnRequest {
-                asset_id: asset_id.clone(),
-                asset_id_str: None,
+                asset_specifier: AssetSpecifier {
+                    asset_id_str: Some(asset_id.clone()),
+                    group_key_str: None,
+                },
                 amount_to_burn: "100".to_string(),
                 confirmation_text: "wrong text".to_string(),
                 note: None,

--- a/tests/integration_scenarios.rs
+++ b/tests/integration_scenarios.rs
@@ -2,7 +2,7 @@ use actix_web::{test, App};
 use serde_json::Value;
 use serial_test::serial;
 use taproot_assets_rest_gateway::api::addresses::NewAddrRequest;
-use taproot_assets_rest_gateway::api::burn::BurnRequest;
+use taproot_assets_rest_gateway::api::burn::{AssetSpecifier, BurnRequest};
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::api::send::SendRequest;
 use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup};
@@ -87,8 +87,10 @@ async fn test_complete_asset_lifecycle() {
 
     // Burn assets
     let burn_req = BurnRequest {
-        asset_id,
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id),
+            group_key_str: None,
+        },
         amount_to_burn: "50".to_string(),
         confirmation_text: "assets will be destroyed".to_string(),
         note: None,

--- a/tests/ui_specific.rs
+++ b/tests/ui_specific.rs
@@ -463,7 +463,7 @@ async fn test_confirmation_dialog_data() {
     .await;
 
     let burn_req = json!({
-        "asset_id": asset_id,
+        "asset_specifier": { "asset_id_str": asset_id },
         "amount_to_burn": "10",
         "confirmation_text": "assets will be destroyed"
     });


### PR DESCRIPTION
Switches `BurnRequest` to tapd's `asset_specifier` field, replacing the deprecated `asset_id` / `asset_id_str` pair.

On `main` the gateway sent a hex string in `asset_id`, which tapd declares as a protobuf `bytes` field (REST-encoded, not a plain hex string). `asset_specifier.asset_id_str` is the field tapd actually intends for REST callers.

Also in this PR:

- `AssetSpecifier::validate()` rejects a request that sets both `asset_id_str` and `group_key_str`, or neither. Previously an empty `{"asset_specifier": {}}` was forwarded to an irreversible endpoint with no gateway-side guard.
- Asset IDs are checked for exactly 64 hex characters; group keys accept 64 or 66, since tapd accepts both x-only and compressed public keys.
- Restores the burn audit log. The refactor had reduced it to a bare `"Burning assets"` string, leaving no record of what was destroyed.

**Requires tapd 0.8.0 or newer.** tapd rejects unknown request fields, so `asset_specifier` fails against 0.7.x with `unknown field "asset_specifier"`.

Verified against a live tapd 0.8.0 regtest node.
