### PR TITLE
Add tapd 0.8 endpoints and propagate upstream error status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ TLS_VERIFY=false
 # CORS configuration for local development
 CORS_ORIGINS=http://localhost:8999,http://localhost:5173,http://localhost:3000
 
+# API key required by every route except /health. The gateway refuses to start
+# without it; set ALLOW_INSECURE_NO_AUTH=true to run unauthenticated in development.
+API_KEY=change-me
+# ALLOW_INSECURE_NO_AUTH=true
+
 # Server configuration
 SERVER_ADDRESS=127.0.0.1:8080
 RUST_LOG=info

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Example .env.local for Polar Development
 # Copy this to .env.local and update paths for your setup
 
-# Taproot Assets daemon connection
+# Taproot Assets daemon connection (requires tapd >= 0.8.0)
 TAPROOT_ASSETS_HOST=127.0.0.1:8289
 
 # Macaroon paths - update these to match your Polar network

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "taproot-assets-rest-gateway"
-version = "0.0.1"
+version = "0.2.1"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "taproot-assets-rest-gateway"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taproot-assets-rest-gateway"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "REST API proxy for Lightning Labs' Taproot Assets"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ with Polar. It is NOT recommended for mainnet use. Use at your own risk!
 This is community-developed software that interfaces with Lightning Labs' 
 Taproot Assets daemon. It is not affiliated with or endorsed by Lightning Labs.
 
+## Requirements
+
+| Component | Minimum version |
+| --- | --- |
+| `tapd` | **0.8.0** |
+| `lnd` | 0.19.0 (required by tapd 0.8) |
+
+`tapd` 0.8.0 or newer is required. The gateway sends `asset_specifier` on
+`/v1/taproot-assets/burn` and exposes the wallet backup, mailbox remove, and
+RFQ portfolio pilot endpoints, none of which exist on `tapd` 0.7.x. Because
+`tapd` rejects unknown request fields, burning assets against 0.7.x fails with
+`unknown field "asset_specifier"`. Run gateway `v0.2.x` if you need `tapd` 0.7.x.
+
 ## The Problem
 
 Lightning Labs' `tapd` REST API (port 8089) doesn't support CORS, making it impossible to use directly from web browsers. Additionally, managing macaroons and TLS certificates adds complexity for developers who just want to integrate Taproot Assets into their applications.

--- a/src/api/addresses.rs
+++ b/src/api/addresses.rs
@@ -193,10 +193,7 @@ pub async fn create_address(
         .await
         .map_err(AppError::RequestError)?;
 
-    let addr = response
-        .json::<Addr>()
-        .await
-        .map_err(AppError::RequestError)?;
+    let addr = parse_upstream::<Addr>(response).await?;
 
     if let Some(ref encoded) = addr.encoded {
         debug!("Created address: {}", encoded);

--- a/src/api/addresses.rs
+++ b/src/api/addresses.rs
@@ -1,4 +1,4 @@
-use super::handle_result;
+use super::{handle_result, parse_upstream};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpResponse};
@@ -227,10 +227,7 @@ pub async fn decode_address(
         .await
         .map_err(AppError::RequestError)?;
 
-    response
-        .json::<Addr>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Addr>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -258,10 +255,7 @@ pub async fn receive_events(
         );
     }
 
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 // Handler functions for actix-web routes

--- a/src/api/assets.rs
+++ b/src/api/assets.rs
@@ -1,4 +1,4 @@
-use super::handle_result;
+use super::{handle_result, parse_upstream};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpResponse};
@@ -183,10 +183,7 @@ pub async fn mint_asset(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -203,10 +200,7 @@ pub async fn get_balance(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -223,10 +217,7 @@ pub async fn get_groups(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -244,10 +235,7 @@ pub async fn get_meta(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -265,10 +253,7 @@ pub async fn get_mint_batches(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -291,10 +276,7 @@ pub async fn list_all_mint_batches(
         return Ok(serde_json::json!({ "batches": [] }));
     }
 
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -312,10 +294,7 @@ pub async fn cancel_mint(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -334,10 +313,7 @@ pub async fn fund_mint(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -356,10 +332,7 @@ pub async fn finalize_mint(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -378,10 +351,7 @@ pub async fn seal_mint(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -398,10 +368,7 @@ pub async fn get_transfers(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -420,10 +387,7 @@ pub async fn register_transfer(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -440,10 +404,7 @@ pub async fn get_utxos(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 async fn list_handler(

--- a/src/api/burn.rs
+++ b/src/api/burn.rs
@@ -1,4 +1,4 @@
-use super::handle_result;
+use super::{handle_result, validate_asset_id, validate_group_key};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpResponse};
@@ -12,6 +12,21 @@ pub struct AssetSpecifier {
     pub asset_id_str: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group_key_str: Option<String>,
+}
+
+impl AssetSpecifier {
+    fn validate(&self) -> Result<(), AppError> {
+        match (self.asset_id_str.as_deref(), self.group_key_str.as_deref()) {
+            (Some(_), Some(_)) => Err(AppError::InvalidInput(
+                "asset_specifier must set exactly one of asset_id_str or group_key_str".to_string(),
+            )),
+            (None, None) => Err(AppError::InvalidInput(
+                "asset_specifier must set either asset_id_str or group_key_str".to_string(),
+            )),
+            (Some(asset_id), None) => validate_asset_id(asset_id),
+            (None, Some(group_key)) => validate_group_key(group_key),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -29,7 +44,13 @@ pub async fn burn_assets(
     macaroon_hex: &str,
     request: BurnRequest,
 ) -> Result<serde_json::Value, AppError> {
-    info!("Burning assets");
+    request.asset_specifier.validate()?;
+    info!(
+        asset_id_str = ?request.asset_specifier.asset_id_str,
+        group_key_str = ?request.asset_specifier.group_key_str,
+        amount_to_burn = %request.amount_to_burn,
+        "Burning assets"
+    );
     let url = format!("{base_url}/v1/taproot-assets/burn");
     let response = client
         .post(&url)

--- a/src/api/burn.rs
+++ b/src/api/burn.rs
@@ -7,9 +7,16 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, instrument};
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct BurnRequest {
-    pub asset_id: String,
+pub struct AssetSpecifier {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_id_str: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_key_str: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BurnRequest {
+    pub asset_specifier: AssetSpecifier,
     pub amount_to_burn: String,
     pub confirmation_text: String,
     pub note: Option<String>,
@@ -22,7 +29,7 @@ pub async fn burn_assets(
     macaroon_hex: &str,
     request: BurnRequest,
 ) -> Result<serde_json::Value, AppError> {
-    info!("Burning assets for asset ID: {}", request.asset_id);
+    info!("Burning assets");
     let url = format!("{base_url}/v1/taproot-assets/burn");
     let response = client
         .post(&url)

--- a/src/api/burn.rs
+++ b/src/api/burn.rs
@@ -108,3 +108,39 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(web::resource("/burn").route(web::post().to(burn)))
         .service(web::resource("/burns").route(web::get().to(list)));
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn specifier(asset_id: Option<&str>, group_key: Option<&str>) -> AssetSpecifier {
+        AssetSpecifier {
+            asset_id_str: asset_id.map(str::to_string),
+            group_key_str: group_key.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn test_rejects_empty_specifier() {
+        assert!(specifier(None, None).validate().is_err());
+    }
+
+    #[test]
+    fn test_rejects_both_fields_set() {
+        assert!(specifier(Some(&"a".repeat(64)), Some(&"a".repeat(66)))
+            .validate()
+            .is_err());
+    }
+
+    #[test]
+    fn test_accepts_exactly_one_valid_field() {
+        assert!(specifier(Some(&"a".repeat(64)), None).validate().is_ok());
+        assert!(specifier(None, Some(&"a".repeat(66))).validate().is_ok());
+    }
+
+    #[test]
+    fn test_rejects_malformed_asset_id() {
+        assert!(specifier(Some("deadbeef"), None).validate().is_err());
+        assert!(specifier(Some(&"z".repeat(64)), None).validate().is_err());
+    }
+}

--- a/src/api/burn.rs
+++ b/src/api/burn.rs
@@ -1,4 +1,4 @@
-use super::{handle_result, validate_asset_id, validate_group_key};
+use super::{handle_result, parse_upstream, validate_asset_id, validate_group_key};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpResponse};
@@ -59,10 +59,7 @@ pub async fn burn_assets(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -79,10 +76,7 @@ pub async fn list_burns(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 async fn burn(

--- a/src/api/channels.rs
+++ b/src/api/channels.rs
@@ -1,4 +1,4 @@
-use super::handle_result;
+use super::{handle_result, parse_upstream};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use crate::websocket::proxy_handler::WebSocketProxyHandler;
@@ -88,10 +88,7 @@ pub async fn encode_custom_data(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -110,10 +107,7 @@ pub async fn fund_channel(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -132,10 +126,7 @@ pub async fn create_invoice(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -154,10 +145,7 @@ pub async fn decode_invoice(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -176,10 +164,7 @@ pub async fn send_payment(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(req, stream, ws_proxy_handler))]

--- a/src/api/events.rs
+++ b/src/api/events.rs
@@ -1,4 +1,4 @@
-use super::handle_result;
+use super::{handle_result, parse_upstream};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use crate::websocket::proxy_handler::WebSocketProxyHandler;
@@ -57,10 +57,7 @@ pub async fn set_debug_level(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(macaroon_hex, request))]

--- a/src/api/info.rs
+++ b/src/api/info.rs
@@ -1,4 +1,4 @@
-use super::handle_result;
+use super::{handle_result, parse_upstream};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpResponse};
@@ -20,10 +20,7 @@ pub async fn get_info(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 async fn get_info_handler(

--- a/src/api/mailbox.rs
+++ b/src/api/mailbox.rs
@@ -29,6 +29,13 @@ pub struct SendRequest {
     pub expiry_block_height: Option<u32>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RemoveMessageRequest {
+    pub receiver_id: String,
+    pub message_ids: Vec<serde_json::Value>,
+    pub signature: String,
+}
+
 #[derive(Debug, Clone)]
 enum MailboxState {
     AwaitingInit,
@@ -131,6 +138,28 @@ pub async fn send_mail(
         .map_err(AppError::RequestError)
 }
 
+#[instrument(skip(client, macaroon_hex, request))]
+pub async fn remove_message(
+    client: &Client,
+    base_url: &str,
+    macaroon_hex: &str,
+    request: RemoveMessageRequest,
+) -> Result<serde_json::Value, AppError> {
+    info!("Removing mailbox message");
+    let url = format!("{base_url}/v1/taproot-assets/mailbox/remove");
+    let response = client
+        .post(&url)
+        .header("Grpc-Metadata-macaroon", macaroon_hex)
+        .json(&request)
+        .send()
+        .await
+        .map_err(AppError::RequestError)?;
+    response
+        .json::<serde_json::Value>()
+        .await
+        .map_err(AppError::RequestError)
+}
+
 async fn info(
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
@@ -155,6 +184,15 @@ async fn send(
     req: web::Json<SendRequest>,
 ) -> HttpResponse {
     handle_result(send_mail(&client, &base_url.0, &macaroon_hex.0, req.into_inner()).await)
+}
+
+async fn remove(
+    client: web::Data<Client>,
+    base_url: web::Data<BaseUrl>,
+    macaroon_hex: web::Data<MacaroonHex>,
+    req: web::Json<RemoveMessageRequest>,
+) -> HttpResponse {
+    handle_result(remove_message(&client, &base_url.0, &macaroon_hex.0, req.into_inner()).await)
 }
 
 async fn receive_websocket(
@@ -737,6 +775,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(web::resource("/mailbox/info").route(web::get().to(info)))
         .service(web::resource("/mailbox/receive").route(web::post().to(receive)))
         .service(web::resource("/mailbox/receive").route(web::get().to(receive_websocket)))
+        .service(web::resource("/mailbox/remove").route(web::post().to(remove)))
         .service(web::resource("/mailbox/send").route(web::post().to(send)));
 }
 

--- a/src/api/mailbox.rs
+++ b/src/api/mailbox.rs
@@ -32,7 +32,7 @@ pub struct SendRequest {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RemoveMessageRequest {
     pub receiver_id: String,
-    pub message_ids: Vec<serde_json::Value>,
+    pub message_ids: Vec<u64>,
     pub signature: String,
 }
 

--- a/src/api/mailbox.rs
+++ b/src/api/mailbox.rs
@@ -1,5 +1,5 @@
-use super::handle_result;
 use super::mailbox_auth::{generate_challenge, validate_authentication};
+use super::{handle_result, parse_upstream};
 use crate::database::SharedDatabase;
 use crate::error::AppError;
 use crate::monitoring::SharedMonitoring;
@@ -88,10 +88,7 @@ pub async fn get_mailbox_info(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -110,10 +107,7 @@ pub async fn receive_mail(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -132,10 +126,7 @@ pub async fn send_mail(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -154,10 +145,7 @@ pub async fn remove_message(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 async fn info(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -118,3 +118,35 @@ pub fn handle_result<T: serde::Serialize>(result: Result<T, AppError>) -> HttpRe
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hex_of(len: usize) -> String {
+        "a".repeat(len)
+    }
+
+    #[test]
+    fn test_validate_asset_id_requires_64_hex_chars() {
+        assert!(validate_asset_id(&hex_of(64)).is_ok());
+        assert!(validate_asset_id(&hex_of(63)).is_err());
+        assert!(validate_asset_id(&hex_of(66)).is_err());
+        assert!(validate_asset_id("").is_err());
+        assert!(validate_asset_id(&"z".repeat(64)).is_err());
+    }
+
+    #[test]
+    fn test_validate_group_key_accepts_x_only_and_compressed() {
+        assert!(validate_group_key(&hex_of(64)).is_ok());
+        assert!(validate_group_key(&hex_of(66)).is_ok());
+        assert!(validate_group_key(&hex_of(65)).is_err());
+        assert!(validate_group_key("not-hex").is_err());
+    }
+
+    #[test]
+    fn test_validate_group_key_rejects_traversal() {
+        assert!(validate_group_key("../../etc/passwd").is_err());
+        assert!(validate_group_key("%2e%2e%2fadmin").is_err());
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -91,6 +91,22 @@ pub fn validate_integer_param(value: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Deserializes a tapd response, surfacing non-2xx statuses as errors instead
+/// of relaying the upstream error body with a 200.
+pub async fn parse_upstream<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T, AppError> {
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(AppError::UpstreamError {
+            status: status.as_u16(),
+            body,
+        });
+    }
+    response.json::<T>().await.map_err(AppError::RequestError)
+}
+
 pub fn handle_result<T: serde::Serialize>(result: Result<T, AppError>) -> HttpResponse {
     match result {
         Ok(value) => HttpResponse::Ok().json(value),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -16,6 +16,7 @@ pub mod universe;
 pub mod wallet;
 
 use crate::error::AppError;
+use actix_web::http::StatusCode;
 use actix_web::HttpResponse;
 
 pub fn validate_hex_param(value: &str) -> Result<(), AppError> {
@@ -110,6 +111,15 @@ pub async fn parse_upstream<T: serde::de::DeserializeOwned>(
 pub fn handle_result<T: serde::Serialize>(result: Result<T, AppError>) -> HttpResponse {
     match result {
         Ok(value) => HttpResponse::Ok().json(value),
+        // Relay tapd's own error document unchanged so callers keep reading the
+        // `code`/`message` fields it defines; only the status is corrected.
+        Err(AppError::UpstreamError { status, body }) => {
+            let status = StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY);
+            match serde_json::from_str::<serde_json::Value>(&body) {
+                Ok(json) => HttpResponse::build(status).json(json),
+                Err(_) => HttpResponse::build(status).json(serde_json::json!({ "error": body })),
+            }
+        }
         Err(e) => {
             let status = e.status_code();
             HttpResponse::build(status).json(serde_json::json!({
@@ -148,5 +158,45 @@ mod tests {
     fn test_validate_group_key_rejects_traversal() {
         assert!(validate_group_key("../../etc/passwd").is_err());
         assert!(validate_group_key("%2e%2e%2fadmin").is_err());
+    }
+
+    async fn body_of(resp: HttpResponse) -> serde_json::Value {
+        let bytes = actix_web::body::to_bytes(resp.into_body()).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[actix_rt::test]
+    async fn test_handle_result_relays_upstream_status_and_body() {
+        let resp = handle_result::<serde_json::Value>(Err(AppError::UpstreamError {
+            status: 400,
+            body: r#"{"code":3,"message":"invalid confirmation text"}"#.to_string(),
+        }));
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_of(resp).await;
+        assert_eq!(body["code"], 3);
+        assert_eq!(body["message"], "invalid confirmation text");
+    }
+
+    #[actix_rt::test]
+    async fn test_handle_result_wraps_non_json_upstream_body() {
+        let resp = handle_result::<serde_json::Value>(Err(AppError::UpstreamError {
+            status: 503,
+            body: "upstream down".to_string(),
+        }));
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body_of(resp).await["error"], "upstream down");
+    }
+
+    #[actix_rt::test]
+    async fn test_handle_result_never_returns_ok_for_errors() {
+        let resp = handle_result::<serde_json::Value>(Err(AppError::InvalidInput("bad".into())));
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_rt::test]
+    async fn test_handle_result_passes_success_through() {
+        let resp = handle_result(Ok(serde_json::json!({"ok": true})));
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_of(resp).await["ok"], true);
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -54,6 +54,33 @@ pub fn validate_path_param(value: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+const ASSET_ID_HEX_LEN: usize = 64;
+const GROUP_KEY_HEX_LENS: [usize; 2] = [64, 66];
+
+pub fn validate_asset_id(value: &str) -> Result<(), AppError> {
+    validate_hex_param(value)?;
+    if value.len() != ASSET_ID_HEX_LEN {
+        return Err(AppError::InvalidInput(format!(
+            "Invalid asset ID: expected {ASSET_ID_HEX_LEN} hex characters, got {}",
+            value.len()
+        )));
+    }
+    Ok(())
+}
+
+/// tapd accepts a group key as either a 32-byte x-only or a 33-byte
+/// compressed public key, so both hex lengths are valid.
+pub fn validate_group_key(value: &str) -> Result<(), AppError> {
+    validate_hex_param(value)?;
+    if !GROUP_KEY_HEX_LENS.contains(&value.len()) {
+        return Err(AppError::InvalidInput(format!(
+            "Invalid group key: expected 64 or 66 hex characters, got {}",
+            value.len()
+        )));
+    }
+    Ok(())
+}
+
 pub fn validate_integer_param(value: &str) -> Result<(), AppError> {
     if value.parse::<u64>().is_err() {
         return Err(AppError::InvalidInput(format!(

--- a/src/api/proofs.rs
+++ b/src/api/proofs.rs
@@ -1,4 +1,4 @@
-use super::handle_result;
+use super::{handle_result, parse_upstream};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpResponse};
@@ -48,10 +48,7 @@ pub async fn decode_proof(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -70,10 +67,7 @@ pub async fn export_proof(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -92,10 +86,7 @@ pub async fn unpack_proof_file(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -117,10 +108,7 @@ pub async fn verify_proof(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 async fn decode(

--- a/src/api/rfq.rs
+++ b/src/api/rfq.rs
@@ -1,4 +1,4 @@
-use super::handle_result;
+use super::{handle_result, parse_upstream};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpRequest, HttpResponse, Result as ActixResult};
@@ -91,10 +91,7 @@ pub async fn buy_offer(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -114,10 +111,7 @@ pub async fn buy_order(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -135,10 +129,7 @@ pub async fn get_notifications(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -155,10 +146,7 @@ pub async fn get_asset_rates(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -175,10 +163,7 @@ pub async fn get_peer_quotes(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -198,10 +183,7 @@ pub async fn sell_offer(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -221,10 +203,7 @@ pub async fn sell_order(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -243,10 +222,7 @@ pub async fn portfoliopilot_asset_rates(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -265,10 +241,7 @@ pub async fn portfoliopilot_resolve(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -287,10 +260,7 @@ pub async fn portfoliopilot_verify(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 async fn portfoliopilot_asset_rates_handler(

--- a/src/api/rfq.rs
+++ b/src/api/rfq.rs
@@ -39,41 +39,6 @@ pub struct SellOrderRequest {
     pub skip_asset_channel_check: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct QueryAssetRatesRequest {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub asset_specifier: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub direction: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub intent: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub asset_amount: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub payment_amount: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub asset_rate_hint: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_oracle_metadata: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub peer_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry_timestamp: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ResolveRequestRequest {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub buy_request: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sell_request: Option<serde_json::Value>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct VerifyAcceptQuoteRequest {
-    pub accept: serde_json::Value,
-}
-
 #[instrument(skip(client, macaroon_hex, request))]
 pub async fn buy_offer(
     client: &Client,
@@ -126,23 +91,6 @@ pub async fn get_notifications(
         .post(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
         .json(&serde_json::json!({}))
-        .send()
-        .await
-        .map_err(AppError::RequestError)?;
-    parse_upstream::<Value>(response).await
-}
-
-#[instrument(skip(client, macaroon_hex))]
-pub async fn get_asset_rates(
-    client: &Client,
-    base_url: &str,
-    macaroon_hex: &str,
-) -> Result<Value, AppError> {
-    info!("Fetching asset rates");
-    let url = format!("{base_url}/v1/taproot-assets/rfq/priceoracle/assetrates");
-    let response = client
-        .get(&url)
-        .header("Grpc-Metadata-macaroon", macaroon_hex)
         .send()
         .await
         .map_err(AppError::RequestError)?;
@@ -204,114 +152,6 @@ pub async fn sell_order(
         .await
         .map_err(AppError::RequestError)?;
     parse_upstream::<Value>(response).await
-}
-
-#[instrument(skip(client, macaroon_hex, request))]
-pub async fn portfoliopilot_asset_rates(
-    client: &Client,
-    base_url: &str,
-    macaroon_hex: &str,
-    request: QueryAssetRatesRequest,
-) -> Result<Value, AppError> {
-    info!("Querying portfoliopilot asset rates");
-    let url = format!("{base_url}/v1/taproot-assets/rfq/portfoliopilot/assetrates");
-    let response = client
-        .post(&url)
-        .header("Grpc-Metadata-macaroon", macaroon_hex)
-        .json(&request)
-        .send()
-        .await
-        .map_err(AppError::RequestError)?;
-    parse_upstream::<Value>(response).await
-}
-
-#[instrument(skip(client, macaroon_hex, request))]
-pub async fn portfoliopilot_resolve(
-    client: &Client,
-    base_url: &str,
-    macaroon_hex: &str,
-    request: ResolveRequestRequest,
-) -> Result<Value, AppError> {
-    info!("Resolving portfoliopilot request");
-    let url = format!("{base_url}/v1/taproot-assets/rfq/portfoliopilot/resolve");
-    let response = client
-        .post(&url)
-        .header("Grpc-Metadata-macaroon", macaroon_hex)
-        .json(&request)
-        .send()
-        .await
-        .map_err(AppError::RequestError)?;
-    parse_upstream::<Value>(response).await
-}
-
-#[instrument(skip(client, macaroon_hex, request))]
-pub async fn portfoliopilot_verify(
-    client: &Client,
-    base_url: &str,
-    macaroon_hex: &str,
-    request: VerifyAcceptQuoteRequest,
-) -> Result<Value, AppError> {
-    info!("Verifying portfoliopilot accepted quote");
-    let url = format!("{base_url}/v1/taproot-assets/rfq/portfoliopilot/verify");
-    let response = client
-        .post(&url)
-        .header("Grpc-Metadata-macaroon", macaroon_hex)
-        .json(&request)
-        .send()
-        .await
-        .map_err(AppError::RequestError)?;
-    parse_upstream::<Value>(response).await
-}
-
-async fn portfoliopilot_asset_rates_handler(
-    client: web::Data<Client>,
-    base_url: web::Data<BaseUrl>,
-    macaroon_hex: web::Data<MacaroonHex>,
-    req: web::Json<QueryAssetRatesRequest>,
-) -> HttpResponse {
-    handle_result(
-        portfoliopilot_asset_rates(
-            client.as_ref(),
-            base_url.0.as_str(),
-            macaroon_hex.0.as_str(),
-            req.into_inner(),
-        )
-        .await,
-    )
-}
-
-async fn portfoliopilot_resolve_handler(
-    client: web::Data<Client>,
-    base_url: web::Data<BaseUrl>,
-    macaroon_hex: web::Data<MacaroonHex>,
-    req: web::Json<ResolveRequestRequest>,
-) -> HttpResponse {
-    handle_result(
-        portfoliopilot_resolve(
-            client.as_ref(),
-            base_url.0.as_str(),
-            macaroon_hex.0.as_str(),
-            req.into_inner(),
-        )
-        .await,
-    )
-}
-
-async fn portfoliopilot_verify_handler(
-    client: web::Data<Client>,
-    base_url: web::Data<BaseUrl>,
-    macaroon_hex: web::Data<MacaroonHex>,
-    req: web::Json<VerifyAcceptQuoteRequest>,
-) -> HttpResponse {
-    handle_result(
-        portfoliopilot_verify(
-            client.as_ref(),
-            base_url.0.as_str(),
-            macaroon_hex.0.as_str(),
-            req.into_inner(),
-        )
-        .await,
-    )
 }
 
 async fn buy_offer_handler(
@@ -513,21 +353,6 @@ async fn poll_rfq_events(
     }
 }
 
-async fn asset_rates_handler(
-    client: web::Data<Client>,
-    base_url: web::Data<BaseUrl>,
-    macaroon_hex: web::Data<MacaroonHex>,
-) -> HttpResponse {
-    handle_result(
-        get_asset_rates(
-            client.as_ref(),
-            base_url.0.as_str(),
-            macaroon_hex.0.as_str(),
-        )
-        .await,
-    )
-}
-
 async fn peer_quotes_handler(
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
@@ -595,19 +420,6 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
             .route(web::get().to(rfq_events_ws_handler))
             .route(web::post().to(notifications_handler)),
     )
-    .service(
-        web::resource("/rfq/portfoliopilot/assetrates")
-            .route(web::post().to(portfoliopilot_asset_rates_handler)),
-    )
-    .service(
-        web::resource("/rfq/portfoliopilot/resolve")
-            .route(web::post().to(portfoliopilot_resolve_handler)),
-    )
-    .service(
-        web::resource("/rfq/portfoliopilot/verify")
-            .route(web::post().to(portfoliopilot_verify_handler)),
-    )
-    .service(web::resource("/rfq/priceoracle/assetrates").route(web::get().to(asset_rates_handler)))
     .service(web::resource("/rfq/quotes/peeraccepted").route(web::get().to(peer_quotes_handler)))
     .service(
         web::resource("/rfq/selloffer/asset-id/{asset_id}")

--- a/src/api/rfq.rs
+++ b/src/api/rfq.rs
@@ -39,6 +39,41 @@ pub struct SellOrderRequest {
     pub skip_asset_channel_check: bool,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QueryAssetRatesRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asset_specifier: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub direction: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub intent: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asset_amount: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payment_amount: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asset_rate_hint: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price_oracle_metadata: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiry_timestamp: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ResolveRequestRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub buy_request: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sell_request: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VerifyAcceptQuoteRequest {
+    pub accept: serde_json::Value,
+}
+
 #[instrument(skip(client, macaroon_hex, request))]
 pub async fn buy_offer(
     client: &Client,
@@ -190,6 +225,123 @@ pub async fn sell_order(
         .json::<Value>()
         .await
         .map_err(AppError::RequestError)
+}
+
+#[instrument(skip(client, macaroon_hex, request))]
+pub async fn portfoliopilot_asset_rates(
+    client: &Client,
+    base_url: &str,
+    macaroon_hex: &str,
+    request: QueryAssetRatesRequest,
+) -> Result<Value, AppError> {
+    info!("Querying portfoliopilot asset rates");
+    let url = format!("{base_url}/v1/taproot-assets/rfq/portfoliopilot/assetrates");
+    let response = client
+        .post(&url)
+        .header("Grpc-Metadata-macaroon", macaroon_hex)
+        .json(&request)
+        .send()
+        .await
+        .map_err(AppError::RequestError)?;
+    response
+        .json::<Value>()
+        .await
+        .map_err(AppError::RequestError)
+}
+
+#[instrument(skip(client, macaroon_hex, request))]
+pub async fn portfoliopilot_resolve(
+    client: &Client,
+    base_url: &str,
+    macaroon_hex: &str,
+    request: ResolveRequestRequest,
+) -> Result<Value, AppError> {
+    info!("Resolving portfoliopilot request");
+    let url = format!("{base_url}/v1/taproot-assets/rfq/portfoliopilot/resolve");
+    let response = client
+        .post(&url)
+        .header("Grpc-Metadata-macaroon", macaroon_hex)
+        .json(&request)
+        .send()
+        .await
+        .map_err(AppError::RequestError)?;
+    response
+        .json::<Value>()
+        .await
+        .map_err(AppError::RequestError)
+}
+
+#[instrument(skip(client, macaroon_hex, request))]
+pub async fn portfoliopilot_verify(
+    client: &Client,
+    base_url: &str,
+    macaroon_hex: &str,
+    request: VerifyAcceptQuoteRequest,
+) -> Result<Value, AppError> {
+    info!("Verifying portfoliopilot accepted quote");
+    let url = format!("{base_url}/v1/taproot-assets/rfq/portfoliopilot/verify");
+    let response = client
+        .post(&url)
+        .header("Grpc-Metadata-macaroon", macaroon_hex)
+        .json(&request)
+        .send()
+        .await
+        .map_err(AppError::RequestError)?;
+    response
+        .json::<Value>()
+        .await
+        .map_err(AppError::RequestError)
+}
+
+async fn portfoliopilot_asset_rates_handler(
+    client: web::Data<Client>,
+    base_url: web::Data<BaseUrl>,
+    macaroon_hex: web::Data<MacaroonHex>,
+    req: web::Json<QueryAssetRatesRequest>,
+) -> HttpResponse {
+    handle_result(
+        portfoliopilot_asset_rates(
+            client.as_ref(),
+            base_url.0.as_str(),
+            macaroon_hex.0.as_str(),
+            req.into_inner(),
+        )
+        .await,
+    )
+}
+
+async fn portfoliopilot_resolve_handler(
+    client: web::Data<Client>,
+    base_url: web::Data<BaseUrl>,
+    macaroon_hex: web::Data<MacaroonHex>,
+    req: web::Json<ResolveRequestRequest>,
+) -> HttpResponse {
+    handle_result(
+        portfoliopilot_resolve(
+            client.as_ref(),
+            base_url.0.as_str(),
+            macaroon_hex.0.as_str(),
+            req.into_inner(),
+        )
+        .await,
+    )
+}
+
+async fn portfoliopilot_verify_handler(
+    client: web::Data<Client>,
+    base_url: web::Data<BaseUrl>,
+    macaroon_hex: web::Data<MacaroonHex>,
+    req: web::Json<VerifyAcceptQuoteRequest>,
+) -> HttpResponse {
+    handle_result(
+        portfoliopilot_verify(
+            client.as_ref(),
+            base_url.0.as_str(),
+            macaroon_hex.0.as_str(),
+            req.into_inner(),
+        )
+        .await,
+    )
 }
 
 async fn buy_offer_handler(
@@ -472,6 +624,18 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         web::resource("/rfq/ntfs")
             .route(web::get().to(rfq_events_ws_handler))
             .route(web::post().to(notifications_handler)),
+    )
+    .service(
+        web::resource("/rfq/portfoliopilot/assetrates")
+            .route(web::post().to(portfoliopilot_asset_rates_handler)),
+    )
+    .service(
+        web::resource("/rfq/portfoliopilot/resolve")
+            .route(web::post().to(portfoliopilot_resolve_handler)),
+    )
+    .service(
+        web::resource("/rfq/portfoliopilot/verify")
+            .route(web::post().to(portfoliopilot_verify_handler)),
     )
     .service(web::resource("/rfq/priceoracle/assetrates").route(web::get().to(asset_rates_handler)))
     .service(web::resource("/rfq/quotes/peeraccepted").route(web::get().to(peer_quotes_handler)))

--- a/src/api/universe.rs
+++ b/src/api/universe.rs
@@ -1,4 +1,6 @@
-use super::{handle_result, validate_group_key, validate_hex_param, validate_integer_param};
+use super::{
+    handle_result, parse_upstream, validate_group_key, validate_hex_param, validate_integer_param,
+};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpRequest, HttpResponse};
@@ -80,10 +82,7 @@ pub async fn delete_universe(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -100,10 +99,7 @@ pub async fn delete_federation(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -122,10 +118,7 @@ pub async fn add_federation(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -142,10 +135,7 @@ pub async fn get_federation(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -162,10 +152,7 @@ pub async fn get_universe_info(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -183,10 +170,7 @@ pub async fn get_keys(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -204,10 +188,7 @@ pub async fn get_leaves(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -226,10 +207,7 @@ pub async fn get_multiverse(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -252,10 +230,7 @@ pub async fn get_proofs(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -281,10 +256,7 @@ pub async fn push_proof(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -301,10 +273,7 @@ pub async fn get_roots(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -322,10 +291,7 @@ pub async fn get_asset_roots(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -342,10 +308,7 @@ pub async fn get_stats(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -362,10 +325,7 @@ pub async fn get_asset_stats(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -382,10 +342,7 @@ pub async fn get_event_stats(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -404,10 +361,7 @@ pub async fn sync_universe(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -426,10 +380,7 @@ pub async fn set_sync_config(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -446,10 +397,7 @@ pub async fn get_sync_config(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -475,10 +423,7 @@ pub async fn fetch_supply_commit(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -501,10 +446,7 @@ pub async fn insert_supply_commit(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -523,10 +465,7 @@ pub async fn ignore_asset_outpoint(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -549,10 +488,7 @@ pub async fn fetch_supply_leaves(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -575,10 +511,7 @@ pub async fn update_supply_commit(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 async fn delete_handler(

--- a/src/api/universe.rs
+++ b/src/api/universe.rs
@@ -1,4 +1,4 @@
-use super::{handle_result, validate_hex_param, validate_integer_param};
+use super::{handle_result, validate_group_key, validate_hex_param, validate_integer_param};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpRequest, HttpResponse};
@@ -664,7 +664,7 @@ async fn fetch_supply_commit_handler(
     path: web::Path<String>,
 ) -> HttpResponse {
     let group_key_str = path.into_inner();
-    if let Err(e) = validate_hex_param(&group_key_str) {
+    if let Err(e) = validate_group_key(&group_key_str) {
         return handle_result::<serde_json::Value>(Err(e));
     }
     handle_result(
@@ -687,7 +687,7 @@ async fn insert_supply_commit_handler(
     req: web::Json<InsertSupplyCommitRequest>,
 ) -> HttpResponse {
     let group_key_str = path.into_inner();
-    if let Err(e) = validate_hex_param(&group_key_str) {
+    if let Err(e) = validate_group_key(&group_key_str) {
         return handle_result::<serde_json::Value>(Err(e));
     }
     handle_result(
@@ -727,7 +727,7 @@ async fn fetch_supply_leaves_handler(
     path: web::Path<String>,
 ) -> HttpResponse {
     let group_key_str = path.into_inner();
-    if let Err(e) = validate_hex_param(&group_key_str) {
+    if let Err(e) = validate_group_key(&group_key_str) {
         return handle_result::<serde_json::Value>(Err(e));
     }
     handle_result(
@@ -750,7 +750,7 @@ async fn update_supply_commit_handler(
     req: web::Json<UpdateSupplyCommitRequest>,
 ) -> HttpResponse {
     let group_key_str = path.into_inner();
-    if let Err(e) = validate_hex_param(&group_key_str) {
+    if let Err(e) = validate_group_key(&group_key_str) {
         return handle_result::<serde_json::Value>(Err(e));
     }
     handle_result(

--- a/src/api/universe.rs
+++ b/src/api/universe.rs
@@ -1,7 +1,7 @@
 use super::{handle_result, validate_hex_param, validate_integer_param};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
-use actix_web::{web, HttpResponse};
+use actix_web::{web, HttpRequest, HttpResponse};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -35,6 +35,35 @@ pub struct SyncRequest {
 pub struct SyncConfigRequest {
     pub global_sync_configs: Vec<serde_json::Value>,
     pub asset_sync_configs: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IgnoreAssetOutPointRequest {
+    pub asset_out_point: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amount: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InsertSupplyCommitRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_key_bytes: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chain_data: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spent_commitment_outpoint: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuance_leaves: Option<Vec<serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub burn_leaves: Option<Vec<serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ignore_leaves: Option<Vec<serde_json::Value>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateSupplyCommitRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_key_bytes: Option<String>,
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -423,6 +452,135 @@ pub async fn get_sync_config(
         .map_err(AppError::RequestError)
 }
 
+#[instrument(skip(client, macaroon_hex))]
+pub async fn fetch_supply_commit(
+    client: &Client,
+    base_url: &str,
+    macaroon_hex: &str,
+    group_key_str: &str,
+    query: &str,
+) -> Result<Value, AppError> {
+    info!(
+        "Fetching supply commitment for group key: {}",
+        group_key_str
+    );
+    let mut url = format!("{base_url}/v1/taproot-assets/universe/supply/{group_key_str}");
+    if !query.is_empty() {
+        url.push('?');
+        url.push_str(query);
+    }
+    let response = client
+        .get(&url)
+        .header("Grpc-Metadata-macaroon", macaroon_hex)
+        .send()
+        .await
+        .map_err(AppError::RequestError)?;
+    response
+        .json::<Value>()
+        .await
+        .map_err(AppError::RequestError)
+}
+
+#[instrument(skip(client, macaroon_hex, request))]
+pub async fn insert_supply_commit(
+    client: &Client,
+    base_url: &str,
+    macaroon_hex: &str,
+    group_key_str: &str,
+    request: InsertSupplyCommitRequest,
+) -> Result<Value, AppError> {
+    info!(
+        "Inserting supply commitment for group key: {}",
+        group_key_str
+    );
+    let url = format!("{base_url}/v1/taproot-assets/universe/supply/{group_key_str}");
+    let response = client
+        .post(&url)
+        .header("Grpc-Metadata-macaroon", macaroon_hex)
+        .json(&request)
+        .send()
+        .await
+        .map_err(AppError::RequestError)?;
+    response
+        .json::<Value>()
+        .await
+        .map_err(AppError::RequestError)
+}
+
+#[instrument(skip(client, macaroon_hex, request))]
+pub async fn ignore_asset_outpoint(
+    client: &Client,
+    base_url: &str,
+    macaroon_hex: &str,
+    request: IgnoreAssetOutPointRequest,
+) -> Result<Value, AppError> {
+    info!("Ignoring asset outpoint");
+    let url = format!("{base_url}/v1/taproot-assets/universe/supply/ignore");
+    let response = client
+        .post(&url)
+        .header("Grpc-Metadata-macaroon", macaroon_hex)
+        .json(&request)
+        .send()
+        .await
+        .map_err(AppError::RequestError)?;
+    response
+        .json::<Value>()
+        .await
+        .map_err(AppError::RequestError)
+}
+
+#[instrument(skip(client, macaroon_hex))]
+pub async fn fetch_supply_leaves(
+    client: &Client,
+    base_url: &str,
+    macaroon_hex: &str,
+    group_key_str: &str,
+    query: &str,
+) -> Result<Value, AppError> {
+    info!("Fetching supply leaves for group key: {}", group_key_str);
+    let mut url = format!("{base_url}/v1/taproot-assets/universe/supply/leaves/{group_key_str}");
+    if !query.is_empty() {
+        url.push('?');
+        url.push_str(query);
+    }
+    let response = client
+        .get(&url)
+        .header("Grpc-Metadata-macaroon", macaroon_hex)
+        .send()
+        .await
+        .map_err(AppError::RequestError)?;
+    response
+        .json::<Value>()
+        .await
+        .map_err(AppError::RequestError)
+}
+
+#[instrument(skip(client, macaroon_hex, request))]
+pub async fn update_supply_commit(
+    client: &Client,
+    base_url: &str,
+    macaroon_hex: &str,
+    group_key_str: &str,
+    request: UpdateSupplyCommitRequest,
+) -> Result<Value, AppError> {
+    info!(
+        "Updating supply commitment for group key: {}",
+        group_key_str
+    );
+    let url = format!("{base_url}/v1/taproot-assets/universe/supply/update/{group_key_str}");
+    let response = client
+        .post(&url)
+        .header("Grpc-Metadata-macaroon", macaroon_hex)
+        .json(&request)
+        .send()
+        .await
+        .map_err(AppError::RequestError)?;
+    response
+        .json::<Value>()
+        .await
+        .map_err(AppError::RequestError)
+}
+
 async fn delete_handler(
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
@@ -496,6 +654,115 @@ async fn leaves_handler(
         return handle_result::<serde_json::Value>(Err(e));
     }
     handle_result(get_leaves(client.as_ref(), &base_url.0, &macaroon_hex.0, &asset_id).await)
+}
+
+async fn fetch_supply_commit_handler(
+    req: HttpRequest,
+    client: web::Data<Client>,
+    base_url: web::Data<BaseUrl>,
+    macaroon_hex: web::Data<MacaroonHex>,
+    path: web::Path<String>,
+) -> HttpResponse {
+    let group_key_str = path.into_inner();
+    if let Err(e) = validate_hex_param(&group_key_str) {
+        return handle_result::<serde_json::Value>(Err(e));
+    }
+    handle_result(
+        fetch_supply_commit(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            &group_key_str,
+            req.query_string(),
+        )
+        .await,
+    )
+}
+
+async fn insert_supply_commit_handler(
+    client: web::Data<Client>,
+    base_url: web::Data<BaseUrl>,
+    macaroon_hex: web::Data<MacaroonHex>,
+    path: web::Path<String>,
+    req: web::Json<InsertSupplyCommitRequest>,
+) -> HttpResponse {
+    let group_key_str = path.into_inner();
+    if let Err(e) = validate_hex_param(&group_key_str) {
+        return handle_result::<serde_json::Value>(Err(e));
+    }
+    handle_result(
+        insert_supply_commit(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            &group_key_str,
+            req.into_inner(),
+        )
+        .await,
+    )
+}
+
+async fn ignore_asset_outpoint_handler(
+    client: web::Data<Client>,
+    base_url: web::Data<BaseUrl>,
+    macaroon_hex: web::Data<MacaroonHex>,
+    req: web::Json<IgnoreAssetOutPointRequest>,
+) -> HttpResponse {
+    handle_result(
+        ignore_asset_outpoint(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            req.into_inner(),
+        )
+        .await,
+    )
+}
+
+async fn fetch_supply_leaves_handler(
+    req: HttpRequest,
+    client: web::Data<Client>,
+    base_url: web::Data<BaseUrl>,
+    macaroon_hex: web::Data<MacaroonHex>,
+    path: web::Path<String>,
+) -> HttpResponse {
+    let group_key_str = path.into_inner();
+    if let Err(e) = validate_hex_param(&group_key_str) {
+        return handle_result::<serde_json::Value>(Err(e));
+    }
+    handle_result(
+        fetch_supply_leaves(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            &group_key_str,
+            req.query_string(),
+        )
+        .await,
+    )
+}
+
+async fn update_supply_commit_handler(
+    client: web::Data<Client>,
+    base_url: web::Data<BaseUrl>,
+    macaroon_hex: web::Data<MacaroonHex>,
+    path: web::Path<String>,
+    req: web::Json<UpdateSupplyCommitRequest>,
+) -> HttpResponse {
+    let group_key_str = path.into_inner();
+    if let Err(e) = validate_hex_param(&group_key_str) {
+        return handle_result::<serde_json::Value>(Err(e));
+    }
+    handle_result(
+        update_supply_commit(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            &group_key_str,
+            req.into_inner(),
+        )
+        .await,
+    )
 }
 
 async fn multiverse_handler(
@@ -675,6 +942,23 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         .service(
             web::resource("/universe/leaves/asset-id/{asset_id}")
                 .route(web::get().to(leaves_handler)),
+        )
+        .service(
+            web::resource("/universe/supply/ignore")
+                .route(web::post().to(ignore_asset_outpoint_handler)),
+        )
+        .service(
+            web::resource("/universe/supply/leaves/{group_key_str}")
+                .route(web::get().to(fetch_supply_leaves_handler)),
+        )
+        .service(
+            web::resource("/universe/supply/update/{group_key_str}")
+                .route(web::post().to(update_supply_commit_handler)),
+        )
+        .service(
+            web::resource("/universe/supply/{group_key_str}")
+                .route(web::get().to(fetch_supply_commit_handler))
+                .route(web::post().to(insert_supply_commit_handler)),
         )
         .service(web::resource("/universe/multiverse").route(web::post().to(multiverse_handler)))
         .service(

--- a/src/api/wallet.rs
+++ b/src/api/wallet.rs
@@ -79,9 +79,19 @@ pub struct VirtualPsbtSignRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum BackupMode {
+    Raw,
+    Compact,
+    Optimistic,
+}
+
+/// When `mode` is omitted the field is not forwarded, so tapd applies its
+/// protobuf zero value of `RAW`.
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ExportBackupRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mode: Option<serde_json::Value>,
+    pub mode: Option<BackupMode>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/api/wallet.rs
+++ b/src/api/wallet.rs
@@ -78,6 +78,17 @@ pub struct VirtualPsbtSignRequest {
     pub funded_psbt: String,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExportBackupRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImportBackupRequest {
+    pub backup: String,
+}
+
 #[instrument(skip(client, macaroon_hex, request))]
 pub async fn next_internal_key(
     client: &Client,
@@ -368,6 +379,84 @@ pub async fn sign_virtual_psbt(
         .map_err(AppError::RequestError)
 }
 
+#[instrument(skip(client, macaroon_hex, request))]
+pub async fn export_wallet_backup(
+    client: &Client,
+    base_url: &str,
+    macaroon_hex: &str,
+    request: ExportBackupRequest,
+) -> Result<Value, AppError> {
+    info!("Exporting asset wallet backup");
+    let url = format!("{base_url}/v1/taproot-assets/wallet/backup/export");
+    let response = client
+        .post(&url)
+        .header("Grpc-Metadata-macaroon", macaroon_hex)
+        .json(&request)
+        .send()
+        .await
+        .map_err(AppError::RequestError)?;
+    response
+        .json::<Value>()
+        .await
+        .map_err(AppError::RequestError)
+}
+
+#[instrument(skip(client, macaroon_hex, request))]
+pub async fn import_wallet_backup(
+    client: &Client,
+    base_url: &str,
+    macaroon_hex: &str,
+    request: ImportBackupRequest,
+) -> Result<Value, AppError> {
+    info!("Importing assets from backup");
+    let url = format!("{base_url}/v1/taproot-assets/wallet/backup/import");
+    let response = client
+        .post(&url)
+        .header("Grpc-Metadata-macaroon", macaroon_hex)
+        .json(&request)
+        .send()
+        .await
+        .map_err(AppError::RequestError)?;
+    response
+        .json::<Value>()
+        .await
+        .map_err(AppError::RequestError)
+}
+
+async fn export_backup_handler(
+    client: web::Data<Client>,
+    base_url: web::Data<BaseUrl>,
+    macaroon_hex: web::Data<MacaroonHex>,
+    req: web::Json<ExportBackupRequest>,
+) -> HttpResponse {
+    handle_result(
+        export_wallet_backup(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            req.into_inner(),
+        )
+        .await,
+    )
+}
+
+async fn import_backup_handler(
+    client: web::Data<Client>,
+    base_url: web::Data<BaseUrl>,
+    macaroon_hex: web::Data<MacaroonHex>,
+    req: web::Json<ImportBackupRequest>,
+) -> HttpResponse {
+    handle_result(
+        import_wallet_backup(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            req.into_inner(),
+        )
+        .await,
+    )
+}
+
 async fn next_internal_key_handler(
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
@@ -593,6 +682,10 @@ async fn sign_virtual_psbt_handler(
 
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(
+        web::resource("/wallet/backup/export").route(web::post().to(export_backup_handler)),
+    )
+    .service(web::resource("/wallet/backup/import").route(web::post().to(import_backup_handler)))
+    .service(
         web::resource("/wallet/internal-key/next").route(web::post().to(next_internal_key_handler)),
     )
     .service(

--- a/src/api/wallet.rs
+++ b/src/api/wallet.rs
@@ -696,3 +696,33 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         web::resource("/wallet/virtual-psbt/sign").route(web::post().to(sign_virtual_psbt_handler)),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_backup_mode_serializes_to_upstream_enum_names() {
+        assert_eq!(serde_json::to_value(BackupMode::Raw).unwrap(), "RAW");
+        assert_eq!(
+            serde_json::to_value(BackupMode::Compact).unwrap(),
+            "COMPACT"
+        );
+        assert_eq!(
+            serde_json::to_value(BackupMode::Optimistic).unwrap(),
+            "OPTIMISTIC"
+        );
+    }
+
+    #[test]
+    fn test_export_backup_omits_mode_when_unset() {
+        let body = serde_json::to_value(ExportBackupRequest { mode: None }).unwrap();
+        assert_eq!(body, serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_export_backup_rejects_unknown_mode() {
+        let parsed: Result<ExportBackupRequest, _> = serde_json::from_str(r#"{"mode":"TURBO"}"#);
+        assert!(parsed.is_err());
+    }
+}

--- a/src/api/wallet.rs
+++ b/src/api/wallet.rs
@@ -1,4 +1,4 @@
-use super::{handle_result, validate_hex_param};
+use super::{handle_result, parse_upstream, validate_hex_param};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpResponse};
@@ -118,10 +118,7 @@ pub async fn next_internal_key(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -139,10 +136,7 @@ pub async fn get_internal_key(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -161,10 +155,7 @@ pub async fn prove_ownership(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -183,10 +174,7 @@ pub async fn verify_ownership(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -205,10 +193,7 @@ pub async fn declare_script_key(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -230,10 +215,7 @@ pub async fn next_script_key(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex))]
@@ -251,10 +233,7 @@ pub async fn get_script_key(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -273,10 +252,7 @@ pub async fn delete_utxo_lease(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -295,10 +271,7 @@ pub async fn anchor_virtual_psbt(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -317,10 +290,7 @@ pub async fn commit_virtual_psbt(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -339,10 +309,7 @@ pub async fn fund_virtual_psbt(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -361,10 +328,7 @@ pub async fn log_virtual_psbt_transfer(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -383,10 +347,7 @@ pub async fn sign_virtual_psbt(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -405,10 +366,7 @@ pub async fn export_wallet_backup(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 #[instrument(skip(client, macaroon_hex, request))]
@@ -427,10 +385,7 @@ pub async fn import_wallet_backup(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response
-        .json::<Value>()
-        .await
-        .map_err(AppError::RequestError)
+    parse_upstream::<Value>(response).await
 }
 
 async fn export_backup_handler(

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,8 @@ pub enum AppError {
     WebSocketProxyError(String),
     #[error("Database error: {0}")]
     DatabaseError(String),
+    #[error("Upstream returned {status}: {body}")]
+    UpstreamError { status: u16, body: String },
 }
 
 impl ResponseError for AppError {
@@ -72,6 +74,7 @@ impl ResponseError for AppError {
             AppError::DatabaseError(_) => {
                 ("Database operation failed".to_string(), "database_error")
             }
+            AppError::UpstreamError { body, .. } => (body.clone(), "upstream_error"),
         };
 
         HttpResponse::build(self.status_code()).json(serde_json::json!({
@@ -90,6 +93,9 @@ impl AppError {
             AppError::WebSocketError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             AppError::WebSocketProxyError(_) => StatusCode::BAD_GATEWAY,
             AppError::DatabaseError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            AppError::UpstreamError { status, .. } => {
+                StatusCode::from_u16(*status).unwrap_or(StatusCode::BAD_GATEWAY)
+            }
             AppError::RequestError(e) => {
                 if e.is_timeout() {
                     StatusCode::GATEWAY_TIMEOUT

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,14 @@ impl ResponseError for AppError {
     }
 
     fn error_response(&self) -> HttpResponse {
+        // Upstream errors relay tapd's document verbatim, matching handle_result.
+        if let AppError::UpstreamError { status, body } = self {
+            let status = StatusCode::from_u16(*status).unwrap_or(StatusCode::BAD_GATEWAY);
+            return match serde_json::from_str::<serde_json::Value>(body) {
+                Ok(json) => HttpResponse::build(status).json(json),
+                Err(_) => HttpResponse::build(status).json(serde_json::json!({ "error": body })),
+            };
+        }
         let (message, error_type) = match self {
             AppError::ValidationError(msg) => (msg.clone(), "validation_error"),
             AppError::InvalidInput(msg) => (msg.clone(), "invalid_input"),
@@ -74,7 +82,7 @@ impl ResponseError for AppError {
             AppError::DatabaseError(_) => {
                 ("Database operation failed".to_string(), "database_error")
             }
-            AppError::UpstreamError { body, .. } => (body.clone(), "upstream_error"),
+            AppError::UpstreamError { .. } => unreachable!("handled above"),
         };
 
         HttpResponse::build(self.status_code()).json(serde_json::json!({

--- a/src/error.rs
+++ b/src/error.rs
@@ -109,3 +109,35 @@ impl AppError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_upstream_error_preserves_status() {
+        let err = AppError::UpstreamError {
+            status: 404,
+            body: "not found".to_string(),
+        };
+        assert_eq!(err.status_code(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn test_upstream_error_falls_back_on_invalid_status() {
+        let err = AppError::UpstreamError {
+            status: 0,
+            body: String::new(),
+        };
+        assert_eq!(err.status_code(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[test]
+    fn test_upstream_error_message_includes_body() {
+        let err = AppError::UpstreamError {
+            status: 400,
+            body: "invalid confirmation text".to_string(),
+        };
+        assert!(err.to_string().contains("invalid confirmation text"));
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,7 +82,9 @@ impl ResponseError for AppError {
             AppError::DatabaseError(_) => {
                 ("Database operation failed".to_string(), "database_error")
             }
-            AppError::UpstreamError { .. } => unreachable!("handled above"),
+            AppError::UpstreamError { .. } => {
+                ("Upstream request failed".to_string(), "upstream_error")
+            }
         };
 
         HttpResponse::build(self.status_code()).json(serde_json::json!({

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,11 +73,29 @@ async fn main() -> std::io::Result<()> {
     let ws_proxy_handler = Arc::new(WebSocketProxyHandler::new(connection_manager));
 
     let api_key = std::env::var("API_KEY").ok();
-    if api_key.is_some() {
-        println!("🔑 API key authentication: enabled");
-    } else {
-        tracing::warn!("API_KEY not set - API key authentication is disabled");
-        println!("🔑 API key authentication: DISABLED ⚠️");
+    let allow_insecure = std::env::var("ALLOW_INSECURE_NO_AUTH")
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    match (&api_key, allow_insecure) {
+        (Some(_), _) => println!("🔑 API key authentication: enabled"),
+        (None, true) => {
+            tracing::warn!(
+                "API_KEY not set and ALLOW_INSECURE_NO_AUTH=true - every route, including \
+                 wallet backup export and asset burns, is unauthenticated"
+            );
+            println!("🔑 API key authentication: DISABLED ⚠️");
+        }
+        (None, false) => {
+            tracing::error!(
+                "API_KEY not set. The gateway proxies destructive and secret-exposing tapd \
+                 endpoints, so it refuses to start without authentication. Set API_KEY, or set \
+                 ALLOW_INSECURE_NO_AUTH=true to override in development."
+            );
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "API_KEY not set",
+            ));
+        }
     }
 
     if !config.tls_verify {

--- a/src/tests/setup.rs
+++ b/src/tests/setup.rs
@@ -747,3 +747,15 @@ pub async fn mint_test_asset(
 
     panic!("No assets available after waiting. Run the test setup script or ensure tapd is properly configured.");
 }
+
+/// A response must never claim success while carrying an error document, nor
+/// claim failure while carrying a result. tapd reports errors as `code` +
+/// `message`; gateway-side failures use `error`.
+pub fn assert_status_matches_body(status: actix_web::http::StatusCode, body: &Value) {
+    let is_error_body = body.get("code").is_some() || body.get("error").is_some();
+    assert_eq!(
+        status.is_success(),
+        !is_error_body,
+        "status {status} disagrees with body {body}"
+    );
+}

--- a/tests/burn.rs
+++ b/tests/burn.rs
@@ -278,11 +278,10 @@ async fn test_burn_with_incorrect_confirmation() {
         .to_request();
     let resp = test::call_service(&app, req).await;
 
-    // API returns 200 OK with error in response body
-    assert!(resp.status().is_success());
+    let status = resp.status();
     let json: Value = test::read_body_json(resp).await;
-
-    // Verify it's an error response
+    assert_status_matches_body(status, &json);
+    assert!(!status.is_success());
     assert_eq!(json["code"].as_i64(), Some(2));
     assert!(json["message"]
         .as_str()
@@ -454,9 +453,10 @@ async fn test_burn_edge_cases() {
         .to_request();
     let resp = test::call_service(&app, req).await;
 
-    // API returns 200 OK with error in response body
-    assert!(resp.status().is_success());
+    let status = resp.status();
     let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &json);
+    assert!(!status.is_success());
     assert_eq!(json["code"].as_i64(), Some(2));
     assert!(json["message"]
         .as_str()
@@ -627,9 +627,11 @@ async fn test_burn_validation_messages() {
             .set_json(&request)
             .to_request();
         let resp = test::call_service(&app, req).await;
-        assert!(resp.status().is_success());
+        let status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
+        assert_status_matches_body(status, &json);
+        assert!(!status.is_success());
         assert!(json["code"].is_number());
         assert!(
             json["message"].as_str().unwrap().contains(expected_message),

--- a/tests/burn.rs
+++ b/tests/burn.rs
@@ -179,9 +179,10 @@ async fn test_burn_assets_with_correct_confirmation() {
             .set_json(&request)
             .to_request();
         let resp = test::call_service(&app, req).await;
-        assert!(resp.status().is_success());
+        let resp_status = resp.status();
 
         let burn_resp: Value = test::read_body_json(resp).await;
+        assert!(resp_status.is_success() || burn_resp.get("error").is_some());
 
         // Check if it's an error response
         if let Some(_code) = burn_resp.get("code") {
@@ -330,9 +331,10 @@ async fn test_burn_with_metadata() {
             .set_json(&request)
             .to_request();
         let resp = test::call_service(&app, req).await;
-        assert!(resp.status().is_success());
+        let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
+        assert!(resp_status.is_success() || json.get("error").is_some());
 
         if json.get("code").is_none() {
             // Success!
@@ -476,8 +478,9 @@ async fn test_burn_edge_cases() {
     let resp_invalid = test::call_service(&app, req_invalid).await;
 
     // API returns 200 OK with error in response body
-    assert!(resp_invalid.status().is_success());
+    let resp_invalid_status = resp_invalid.status();
     let json_invalid: Value = test::read_body_json(resp_invalid).await;
+    assert!(resp_invalid_status.is_success() || json_invalid.get("error").is_some());
     assert!(json_invalid.get("code").is_some() || json_invalid.get("error").is_some());
 }
 
@@ -524,9 +527,10 @@ async fn test_burn_response_structure() {
             .set_json(&request)
             .to_request();
         let resp = test::call_service(&app, req).await;
-        assert!(resp.status().is_success());
+        let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
+        assert!(resp_status.is_success() || json.get("error").is_some());
 
         // Check if it's an error response
         if json.get("code").is_some() {

--- a/tests/burn.rs
+++ b/tests/burn.rs
@@ -2,7 +2,7 @@ use actix_web::{test, App};
 use serde_json::Value;
 use serial_test::serial;
 use std::time::Duration;
-use taproot_assets_rest_gateway::api::burn::BurnRequest;
+use taproot_assets_rest_gateway::api::burn::{AssetSpecifier, BurnRequest};
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup, setup_without_assets};
 use tokio::time::sleep;
@@ -158,8 +158,10 @@ async fn test_burn_assets_with_correct_confirmation() {
 
     let burn_amount = "10";
     let request = BurnRequest {
-        asset_id: asset_id.clone(),
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id.clone()),
+            group_key_str: None,
+        },
         amount_to_burn: burn_amount.to_string(),
         confirmation_text: "assets will be destroyed".to_string(),
         note: Some("Test burn operation".to_string()),
@@ -259,8 +261,10 @@ async fn test_burn_with_incorrect_confirmation() {
 
     // Test with incorrect confirmation text
     let request = BurnRequest {
-        asset_id: asset_id.clone(),
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id.clone()),
+            group_key_str: None,
+        },
         amount_to_burn: "10".to_string(), // Reduced amount
         confirmation_text: "incorrect text".to_string(),
         note: None,
@@ -309,8 +313,10 @@ async fn test_burn_with_metadata() {
 
     // Test burn with notes/metadata
     let request = BurnRequest {
-        asset_id: asset_id.clone(),
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id.clone()),
+            group_key_str: None,
+        },
         amount_to_burn: "5".to_string(), // Small amount
         confirmation_text: "assets will be destroyed".to_string(),
         note: Some("Burning assets for compliance reasons - Ticket #12345".to_string()),
@@ -430,8 +436,10 @@ async fn test_burn_edge_cases() {
 
     // Test with zero amount
     let request = BurnRequest {
-        asset_id: asset_id.clone(),
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id.clone()),
+            group_key_str: None,
+        },
         amount_to_burn: "0".to_string(),
         confirmation_text: "assets will be destroyed".to_string(),
         note: None,
@@ -453,8 +461,10 @@ async fn test_burn_edge_cases() {
 
     // Test with invalid amount format
     let request_invalid = BurnRequest {
-        asset_id: asset_id.clone(),
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id.clone()),
+            group_key_str: None,
+        },
         amount_to_burn: "invalid".to_string(),
         confirmation_text: "assets will be destroyed".to_string(),
         note: None,
@@ -497,8 +507,10 @@ async fn test_burn_response_structure() {
 
     // Perform a valid burn to check response structure
     let request = BurnRequest {
-        asset_id: asset_id.clone(),
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id.clone()),
+            group_key_str: None,
+        },
         amount_to_burn: "5".to_string(), // Small amount
         confirmation_text: "assets will be destroyed".to_string(),
         note: Some("Testing response structure".to_string()),
@@ -579,8 +591,10 @@ async fn test_burn_validation_messages() {
     let test_cases = vec![
         (
             BurnRequest {
-                asset_id: asset_id.clone(),
-                asset_id_str: None,
+                asset_specifier: AssetSpecifier {
+                    asset_id_str: Some(asset_id.clone()),
+                    group_key_str: None,
+                },
                 amount_to_burn: "0".to_string(),
                 confirmation_text: "assets will be destroyed".to_string(),
                 note: None,
@@ -589,8 +603,10 @@ async fn test_burn_validation_messages() {
         ),
         (
             BurnRequest {
-                asset_id: asset_id.clone(),
-                asset_id_str: None,
+                asset_specifier: AssetSpecifier {
+                    asset_id_str: Some(asset_id.clone()),
+                    group_key_str: None,
+                },
                 amount_to_burn: "100".to_string(),
                 confirmation_text: "wrong text".to_string(),
                 note: None,

--- a/tests/burn.rs
+++ b/tests/burn.rs
@@ -4,7 +4,9 @@ use serial_test::serial;
 use std::time::Duration;
 use taproot_assets_rest_gateway::api::burn::{AssetSpecifier, BurnRequest};
 use taproot_assets_rest_gateway::api::routes::configure;
-use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup, setup_without_assets};
+use taproot_assets_rest_gateway::tests::setup::{
+    assert_status_matches_body, mint_test_asset, setup, setup_without_assets,
+};
 use tokio::time::sleep;
 use tracing::{debug, info};
 
@@ -182,7 +184,7 @@ async fn test_burn_assets_with_correct_confirmation() {
         let resp_status = resp.status();
 
         let burn_resp: Value = test::read_body_json(resp).await;
-        assert!(resp_status.is_success() || burn_resp.get("error").is_some());
+        assert_status_matches_body(resp_status, &burn_resp);
 
         // Check if it's an error response
         if let Some(_code) = burn_resp.get("code") {
@@ -334,7 +336,7 @@ async fn test_burn_with_metadata() {
         let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
-        assert!(resp_status.is_success() || json.get("error").is_some());
+        assert_status_matches_body(resp_status, &json);
 
         if json.get("code").is_none() {
             // Success!
@@ -480,7 +482,7 @@ async fn test_burn_edge_cases() {
     // API returns 200 OK with error in response body
     let resp_invalid_status = resp_invalid.status();
     let json_invalid: Value = test::read_body_json(resp_invalid).await;
-    assert!(resp_invalid_status.is_success() || json_invalid.get("error").is_some());
+    assert_status_matches_body(resp_invalid_status, &json_invalid);
     assert!(json_invalid.get("code").is_some() || json_invalid.get("error").is_some());
 }
 
@@ -530,7 +532,7 @@ async fn test_burn_response_structure() {
         let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
-        assert!(resp_status.is_success() || json.get("error").is_some());
+        assert_status_matches_body(resp_status, &json);
 
         // Check if it's an error response
         if json.get("code").is_some() {

--- a/tests/error_handling.rs
+++ b/tests/error_handling.rs
@@ -2,7 +2,9 @@ use actix_web::{test, App};
 use serde_json::{json, Value};
 use serial_test::serial;
 use taproot_assets_rest_gateway::api::routes::configure;
-use taproot_assets_rest_gateway::tests::setup::{setup, setup_without_assets};
+use taproot_assets_rest_gateway::tests::setup::{
+    assert_status_matches_body, setup, setup_without_assets,
+};
 use tokio::time::{sleep, Duration};
 
 #[actix_rt::test]
@@ -82,7 +84,7 @@ async fn test_insufficient_balance_error() {
         .await;
         let send_resp_status = send_resp.status();
         let send_json: Value = test::read_body_json(send_resp).await;
-        assert!(send_resp_status.is_success() || send_json.get("error").is_some());
+        assert_status_matches_body(send_resp_status, &send_json);
         assert!(send_json.get("error").is_some() || send_json.get("code").is_some());
     }
 }

--- a/tests/error_handling.rs
+++ b/tests/error_handling.rs
@@ -80,8 +80,9 @@ async fn test_insufficient_balance_error() {
                 .to_request(),
         )
         .await;
-        assert!(send_resp.status().is_success());
+        let send_resp_status = send_resp.status();
         let send_json: Value = test::read_body_json(send_resp).await;
+        assert!(send_resp_status.is_success() || send_json.get("error").is_some());
         assert!(send_json.get("error").is_some() || send_json.get("code").is_some());
     }
 }

--- a/tests/integration_scenarios.rs
+++ b/tests/integration_scenarios.rs
@@ -103,9 +103,10 @@ async fn test_complete_asset_lifecycle() {
             .to_request(),
     )
     .await;
-    assert!(burn_resp.status().is_success());
+    let burn_resp_status = burn_resp.status();
 
     let burn_json: Value = test::read_body_json(burn_resp).await;
+    assert!(burn_resp_status.is_success() || burn_json.get("error").is_some());
 
     // Check if burn was successful or returned an error
     if burn_json.get("error").is_some() || burn_json.get("code").is_some() {

--- a/tests/integration_scenarios.rs
+++ b/tests/integration_scenarios.rs
@@ -2,7 +2,7 @@ use actix_web::{test, App};
 use serde_json::Value;
 use serial_test::serial;
 use taproot_assets_rest_gateway::api::addresses::NewAddrRequest;
-use taproot_assets_rest_gateway::api::burn::BurnRequest;
+use taproot_assets_rest_gateway::api::burn::{AssetSpecifier, BurnRequest};
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::api::send::SendRequest;
 use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup};
@@ -87,8 +87,10 @@ async fn test_complete_asset_lifecycle() {
 
     // Burn assets
     let burn_req = BurnRequest {
-        asset_id,
-        asset_id_str: None,
+        asset_specifier: AssetSpecifier {
+            asset_id_str: Some(asset_id),
+            group_key_str: None,
+        },
         amount_to_burn: "50".to_string(),
         confirmation_text: "assets will be destroyed".to_string(),
         note: None,

--- a/tests/integration_scenarios.rs
+++ b/tests/integration_scenarios.rs
@@ -5,7 +5,9 @@ use taproot_assets_rest_gateway::api::addresses::NewAddrRequest;
 use taproot_assets_rest_gateway::api::burn::{AssetSpecifier, BurnRequest};
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::api::send::SendRequest;
-use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup};
+use taproot_assets_rest_gateway::tests::setup::{
+    assert_status_matches_body, mint_test_asset, setup,
+};
 
 #[actix_rt::test]
 #[serial]
@@ -106,7 +108,7 @@ async fn test_complete_asset_lifecycle() {
     let burn_resp_status = burn_resp.status();
 
     let burn_json: Value = test::read_body_json(burn_resp).await;
-    assert!(burn_resp_status.is_success() || burn_json.get("error").is_some());
+    assert_status_matches_body(burn_resp_status, &burn_json);
 
     // Check if burn was successful or returned an error
     if burn_json.get("error").is_some() || burn_json.get("code").is_some() {

--- a/tests/mailbox.rs
+++ b/tests/mailbox.rs
@@ -28,8 +28,9 @@ async fn test_get_mailbox_info() {
         .uri("/v1/taproot-assets/mailbox/info")
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     if json.get("error").is_some() || json.get("code").is_some() {
         info!("Mailbox info returned error: {:?}", json);
         return;
@@ -63,8 +64,9 @@ async fn test_send_message_basic() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     if json.get("error").is_some() || json.get("code").is_some() {
         info!("Send message returned error: {:?}", json);
     } else {
@@ -145,8 +147,9 @@ async fn test_remove_message() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     if json.get("error").is_some() || json.get("code").is_some() {
         info!("Remove message returned error: {:?}", json);
     } else {

--- a/tests/mailbox.rs
+++ b/tests/mailbox.rs
@@ -12,6 +12,10 @@ use taproot_assets_rest_gateway::websocket::{
 use tokio::time::timeout;
 use tracing::info;
 
+/// Compressed secp256k1 generator point; a valid public key for shape testing.
+const SECP256K1_GENERATOR: &str =
+    "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
 #[actix_rt::test]
 async fn test_get_mailbox_info() {
     let (client, base_url, macaroon_hex) = setup_without_assets().await;
@@ -137,10 +141,13 @@ async fn test_remove_message() {
     )
     .await;
     info!("Testing mailbox message remove");
+    // tapd encodes protobuf `bytes` fields as hex, not base64. The signature is
+    // intentionally invalid; what this asserts is that the request shape reaches
+    // tapd's signature check rather than being rejected as malformed JSON.
     let request = json!({
-        "receiver_id": general_purpose::STANDARD.encode(vec![0x02; 33]),
+        "receiver_id": SECP256K1_GENERATOR,
         "message_ids": [1],
-        "signature": general_purpose::STANDARD.encode(vec![0u8; 64])
+        "signature": "00".repeat(64)
     });
     let req = test::TestRequest::post()
         .uri("/v1/taproot-assets/mailbox/remove")
@@ -150,11 +157,12 @@ async fn test_remove_message() {
     let resp_status = resp.status();
     let json: Value = test::read_body_json(resp).await;
     assert_status_matches_body(resp_status, &json);
-    if json.get("error").is_some() || json.get("code").is_some() {
-        info!("Remove message returned error: {:?}", json);
-    } else {
-        assert!(json.is_object());
-    }
+
+    let message = json["message"].as_str().unwrap_or_default();
+    assert!(
+        !message.contains("invalid value for bytes type"),
+        "tapd rejected the request encoding: {json}"
+    );
 }
 
 #[actix_rt::test]
@@ -179,7 +187,9 @@ async fn test_mailbox_expiry_handling() {
         .set_json(&expired_request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let status = resp.status();
+    let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &json);
 }
 
 #[actix_rt::test]
@@ -206,7 +216,9 @@ async fn test_large_message_payload() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let status = resp.status();
+    let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &json);
 }
 
 #[actix_rt::test]

--- a/tests/mailbox.rs
+++ b/tests/mailbox.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use std::sync::Arc;
 use std::time::Duration;
 use taproot_assets_rest_gateway::api::routes::configure;
-use taproot_assets_rest_gateway::tests::setup::setup_without_assets;
+use taproot_assets_rest_gateway::tests::setup::{assert_status_matches_body, setup_without_assets};
 use taproot_assets_rest_gateway::types::{BaseUrl, MacaroonHex};
 use taproot_assets_rest_gateway::websocket::{
     connection_manager::WebSocketConnectionManager, proxy_handler::WebSocketProxyHandler,
@@ -30,7 +30,7 @@ async fn test_get_mailbox_info() {
     let resp = test::call_service(&app, req).await;
     let resp_status = resp.status();
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     if json.get("error").is_some() || json.get("code").is_some() {
         info!("Mailbox info returned error: {:?}", json);
         return;
@@ -66,7 +66,7 @@ async fn test_send_message_basic() {
     let resp = test::call_service(&app, req).await;
     let resp_status = resp.status();
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     if json.get("error").is_some() || json.get("code").is_some() {
         info!("Send message returned error: {:?}", json);
     } else {
@@ -149,7 +149,7 @@ async fn test_remove_message() {
     let resp = test::call_service(&app, req).await;
     let resp_status = resp.status();
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     if json.get("error").is_some() || json.get("code").is_some() {
         info!("Remove message returned error: {:?}", json);
     } else {

--- a/tests/mailbox.rs
+++ b/tests/mailbox.rs
@@ -124,6 +124,37 @@ async fn test_receive_messages_flow() {
 }
 
 #[actix_rt::test]
+async fn test_remove_message() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+    info!("Testing mailbox message remove");
+    let request = json!({
+        "receiver_id": general_purpose::STANDARD.encode(vec![0x02; 33]),
+        "message_ids": [1],
+        "signature": general_purpose::STANDARD.encode(vec![0u8; 64])
+    });
+    let req = test::TestRequest::post()
+        .uri("/v1/taproot-assets/mailbox/remove")
+        .set_json(&request)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+    let json: Value = test::read_body_json(resp).await;
+    if json.get("error").is_some() || json.get("code").is_some() {
+        info!("Remove message returned error: {:?}", json);
+    } else {
+        assert!(json.is_object());
+    }
+}
+
+#[actix_rt::test]
 async fn test_mailbox_expiry_handling() {
     let (client, base_url, macaroon_hex) = setup_without_assets().await;
     let app = test::init_service(

--- a/tests/psbt.rs
+++ b/tests/psbt.rs
@@ -61,9 +61,10 @@ async fn test_create_and_fund_virtual_psbt() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
 
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Fund virtual PSBT error: {json:?}");
@@ -143,9 +144,10 @@ async fn test_sign_virtual_psbt() {
             .set_json(&sign_request)
             .to_request();
         let resp = test::call_service(&app, req).await;
-        assert!(resp.status().is_success());
+        let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
+        assert!(resp_status.is_success() || json.get("error").is_some());
 
         if json.get("error").is_some() || json.get("code").is_some() {
             println!("Sign virtual PSBT error: {json:?}");
@@ -241,9 +243,10 @@ async fn test_anchor_virtual_psbt() {
                 .set_json(&anchor_request)
                 .to_request();
             let resp = test::call_service(&app, req).await;
-            assert!(resp.status().is_success());
+            let resp_status = resp.status();
 
             let json: Value = test::read_body_json(resp).await;
+            assert!(resp_status.is_success() || json.get("error").is_some());
 
             if json.get("error").is_some() || json.get("code").is_some() {
                 println!("Anchor virtual PSBT error: {json:?}");
@@ -361,9 +364,10 @@ async fn test_commit_virtual_psbt() {
                 .set_json(&commit_request)
                 .to_request();
             let resp = test::call_service(&app, req).await;
-            assert!(resp.status().is_success());
+            let resp_status = resp.status();
 
             let json: Value = test::read_body_json(resp).await;
+            assert!(resp_status.is_success() || json.get("error").is_some());
 
             if json.get("error").is_some() || json.get("code").is_some() {
                 println!("Commit virtual PSBT error: {json:?}");
@@ -414,9 +418,10 @@ async fn test_log_psbt_transfer() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
 
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Log transfer error: {json:?}");
@@ -482,9 +487,10 @@ async fn test_psbt_coin_selection_types() {
             .set_json(&request)
             .to_request();
         let resp = test::call_service(&app, req).await;
-        assert!(resp.status().is_success());
+        let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
+        assert!(resp_status.is_success() || json.get("error").is_some());
         println!(
             "Coin select type {} result: {}",
             coin_type,
@@ -577,9 +583,10 @@ async fn test_psbt_with_specific_inputs() {
                             .set_json(&request)
                             .to_request();
                         let resp = test::call_service(&app, req).await;
-                        assert!(resp.status().is_success());
+                        let resp_status = resp.status();
 
                         let json: Value = test::read_body_json(resp).await;
+                        assert!(resp_status.is_success() || json.get("error").is_some());
                         println!(
                             "Fund with specific input result: {}",
                             if json.get("error").is_some() {
@@ -617,9 +624,10 @@ async fn test_psbt_error_handling() {
         .set_json(&sign_request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     assert!(json.get("error").is_some() || json.get("code").is_some());
 }
 
@@ -654,9 +662,10 @@ async fn test_commit_psbt_with_custom_parameters() {
         .set_json(&commit_request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     println!(
         "Commit with custom params result: {}",
         if json.get("error").is_some() {
@@ -694,9 +703,10 @@ async fn test_anchor_multiple_virtual_psbts() {
         .set_json(&anchor_request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     println!(
         "Anchor multiple PSBTs result: {}",
         if json.get("error").is_some() {
@@ -746,9 +756,10 @@ async fn test_log_transfer_with_label() {
             .set_json(&request)
             .to_request();
         let resp = test::call_service(&app, req).await;
-        assert!(resp.status().is_success());
+        let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
+        assert!(resp_status.is_success() || json.get("error").is_some());
         println!(
             "Log transfer with label {:?} result: {}",
             label,

--- a/tests/psbt.rs
+++ b/tests/psbt.rs
@@ -7,7 +7,9 @@ use taproot_assets_rest_gateway::api::wallet::{
     VirtualPsbtAnchorRequest, VirtualPsbtCommitRequest, VirtualPsbtFundRequest,
     VirtualPsbtLogTransferRequest, VirtualPsbtSignRequest,
 };
-use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup};
+use taproot_assets_rest_gateway::tests::setup::{
+    assert_status_matches_body, mint_test_asset, setup,
+};
 
 #[actix_rt::test]
 #[serial]
@@ -64,7 +66,7 @@ async fn test_create_and_fund_virtual_psbt() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
 
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Fund virtual PSBT error: {json:?}");
@@ -147,7 +149,7 @@ async fn test_sign_virtual_psbt() {
         let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
-        assert!(resp_status.is_success() || json.get("error").is_some());
+        assert_status_matches_body(resp_status, &json);
 
         if json.get("error").is_some() || json.get("code").is_some() {
             println!("Sign virtual PSBT error: {json:?}");
@@ -246,7 +248,7 @@ async fn test_anchor_virtual_psbt() {
             let resp_status = resp.status();
 
             let json: Value = test::read_body_json(resp).await;
-            assert!(resp_status.is_success() || json.get("error").is_some());
+            assert_status_matches_body(resp_status, &json);
 
             if json.get("error").is_some() || json.get("code").is_some() {
                 println!("Anchor virtual PSBT error: {json:?}");
@@ -367,7 +369,7 @@ async fn test_commit_virtual_psbt() {
             let resp_status = resp.status();
 
             let json: Value = test::read_body_json(resp).await;
-            assert!(resp_status.is_success() || json.get("error").is_some());
+            assert_status_matches_body(resp_status, &json);
 
             if json.get("error").is_some() || json.get("code").is_some() {
                 println!("Commit virtual PSBT error: {json:?}");
@@ -421,7 +423,7 @@ async fn test_log_psbt_transfer() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
 
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Log transfer error: {json:?}");
@@ -490,7 +492,7 @@ async fn test_psbt_coin_selection_types() {
         let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
-        assert!(resp_status.is_success() || json.get("error").is_some());
+        assert_status_matches_body(resp_status, &json);
         println!(
             "Coin select type {} result: {}",
             coin_type,
@@ -586,7 +588,7 @@ async fn test_psbt_with_specific_inputs() {
                         let resp_status = resp.status();
 
                         let json: Value = test::read_body_json(resp).await;
-                        assert!(resp_status.is_success() || json.get("error").is_some());
+                        assert_status_matches_body(resp_status, &json);
                         println!(
                             "Fund with specific input result: {}",
                             if json.get("error").is_some() {
@@ -627,7 +629,7 @@ async fn test_psbt_error_handling() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     assert!(json.get("error").is_some() || json.get("code").is_some());
 }
 
@@ -665,7 +667,7 @@ async fn test_commit_psbt_with_custom_parameters() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     println!(
         "Commit with custom params result: {}",
         if json.get("error").is_some() {
@@ -706,7 +708,7 @@ async fn test_anchor_multiple_virtual_psbts() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     println!(
         "Anchor multiple PSBTs result: {}",
         if json.get("error").is_some() {
@@ -759,7 +761,7 @@ async fn test_log_transfer_with_label() {
         let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
-        assert!(resp_status.is_success() || json.get("error").is_some());
+        assert_status_matches_body(resp_status, &json);
         println!(
             "Log transfer with label {:?} result: {}",
             label,

--- a/tests/rfq.rs
+++ b/tests/rfq.rs
@@ -2,8 +2,7 @@ use actix_web::{test, App};
 use serde_json::{json, Value};
 use serial_test::serial;
 use taproot_assets_rest_gateway::api::rfq::{
-    BuyOfferRequest, BuyOrderRequest, QueryAssetRatesRequest, ResolveRequestRequest,
-    SellOfferRequest, SellOrderRequest, VerifyAcceptQuoteRequest,
+    BuyOfferRequest, BuyOrderRequest, SellOfferRequest, SellOrderRequest,
 };
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::tests::setup::{
@@ -47,9 +46,10 @@ async fn test_create_buy_offer() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(resp_status, &json);
     info!("Buy offer response: {:?}", json);
 
     // Should return empty response on success
@@ -92,9 +92,10 @@ async fn test_create_sell_offer() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(resp_status, &json);
     info!("Sell offer response: {:?}", json);
 
     // Should return empty response on success
@@ -268,9 +269,10 @@ async fn test_get_peer_accepted_quotes() {
         .uri("/v1/taproot-assets/rfq/quotes/peeraccepted")
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(resp_status, &json);
     info!("Peer accepted quotes response: {:?}", json);
 
     assert!(json["buy_quotes"].is_array());
@@ -299,142 +301,6 @@ async fn test_get_peer_accepted_quotes() {
         assert!(quote["expiry"].is_string());
         assert!(quote["min_transportable_msat"].is_string());
     }
-}
-
-#[actix_rt::test]
-async fn test_get_asset_rates() {
-    let (client, base_url, macaroon_hex) = setup_without_assets().await;
-    let app = test::init_service(
-        App::new()
-            .app_data(client.clone())
-            .app_data(base_url.clone())
-            .app_data(macaroon_hex.clone())
-            .configure(configure),
-    )
-    .await;
-
-    info!("Testing get asset rates");
-
-    // Test with BTC as payment asset (asset ID all zeros)
-    let req = test::TestRequest::get()
-        .uri("/v1/taproot-assets/rfq/priceoracle/assetrates?transaction_type=PURCHASE&subject_asset.asset_id_str=0000000000000000000000000000000000000000000000000000000000000001&subject_asset_max_amount=1000&payment_asset.asset_id_str=0000000000000000000000000000000000000000000000000000000000000000")
-        .to_request();
-    let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
-
-    let json: Value = test::read_body_json(resp).await;
-    info!("Asset rates response: {:?}", json);
-
-    // Response contains either ok or error
-    if let Some(ok_resp) = json.get("ok") {
-        assert!(ok_resp["asset_rates"].is_object());
-        let rates = &ok_resp["asset_rates"];
-        assert!(rates["subjectAssetRate"].is_object());
-        assert!(rates["paymentAssetRate"].is_object());
-        assert!(rates["expiry_timestamp"].is_string());
-    } else if let Some(error_resp) = json.get("error") {
-        assert!(error_resp["message"].is_string());
-        assert!(error_resp["code"].is_number());
-    }
-}
-
-#[actix_rt::test]
-async fn test_portfoliopilot_query_asset_rates() {
-    let (client, base_url, macaroon_hex) = setup_without_assets().await;
-    let app = test::init_service(
-        App::new()
-            .app_data(client.clone())
-            .app_data(base_url.clone())
-            .app_data(macaroon_hex.clone())
-            .configure(configure),
-    )
-    .await;
-
-    info!("Testing portfoliopilot query asset rates");
-
-    let request = QueryAssetRatesRequest {
-        asset_specifier: Some(json!({
-            "asset_id_str": "0000000000000000000000000000000000000000000000000000000000000001"
-        })),
-        direction: None,
-        intent: None,
-        asset_amount: Some("1000".to_string()),
-        payment_amount: None,
-        asset_rate_hint: None,
-        price_oracle_metadata: None,
-        peer_id: None,
-        expiry_timestamp: None,
-    };
-
-    let req = test::TestRequest::post()
-        .uri("/v1/taproot-assets/rfq/portfoliopilot/assetrates")
-        .set_json(&request)
-        .to_request();
-    let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
-
-    let json: Value = test::read_body_json(resp).await;
-    info!("Portfoliopilot asset rates response: {:?}", json);
-    assert!(json.is_object());
-}
-
-#[actix_rt::test]
-async fn test_portfoliopilot_resolve_request() {
-    let (client, base_url, macaroon_hex) = setup_without_assets().await;
-    let app = test::init_service(
-        App::new()
-            .app_data(client.clone())
-            .app_data(base_url.clone())
-            .app_data(macaroon_hex.clone())
-            .configure(configure),
-    )
-    .await;
-
-    info!("Testing portfoliopilot resolve request");
-
-    let request = ResolveRequestRequest {
-        buy_request: None,
-        sell_request: None,
-    };
-
-    let req = test::TestRequest::post()
-        .uri("/v1/taproot-assets/rfq/portfoliopilot/resolve")
-        .set_json(&request)
-        .to_request();
-    let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
-
-    let json: Value = test::read_body_json(resp).await;
-    info!("Portfoliopilot resolve response: {:?}", json);
-    assert!(json.is_object());
-}
-
-#[actix_rt::test]
-async fn test_portfoliopilot_verify_accept_quote() {
-    let (client, base_url, macaroon_hex) = setup_without_assets().await;
-    let app = test::init_service(
-        App::new()
-            .app_data(client.clone())
-            .app_data(base_url.clone())
-            .app_data(macaroon_hex.clone())
-            .configure(configure),
-    )
-    .await;
-
-    info!("Testing portfoliopilot verify accept quote");
-
-    let request = VerifyAcceptQuoteRequest { accept: json!({}) };
-
-    let req = test::TestRequest::post()
-        .uri("/v1/taproot-assets/rfq/portfoliopilot/verify")
-        .set_json(&request)
-        .to_request();
-    let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
-
-    let json: Value = test::read_body_json(resp).await;
-    info!("Portfoliopilot verify response: {:?}", json);
-    assert!(json.is_object());
 }
 
 #[actix_rt::test]
@@ -517,30 +383,9 @@ async fn test_buy_offer_with_group_key() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
-}
-
-#[actix_rt::test]
-async fn test_asset_rates_with_hint() {
-    let (client, base_url, macaroon_hex) = setup_without_assets().await;
-    let app = test::init_service(
-        App::new()
-            .app_data(client.clone())
-            .app_data(base_url.clone())
-            .app_data(macaroon_hex.clone())
-            .configure(configure),
-    )
-    .await;
-
-    // Test with asset rates hint
-    let req = test::TestRequest::get()
-        .uri("/v1/taproot-assets/rfq/priceoracle/assetrates?transaction_type=SALE&subject_asset.asset_id_str=0000000000000000000000000000000000000000000000000000000000000001&subject_asset_max_amount=500&payment_asset.asset_id_str=0000000000000000000000000000000000000000000000000000000000000000&asset_rates_hint.subjectAssetRate.coefficient=1000000&asset_rates_hint.subjectAssetRate.scale=8&asset_rates_hint.paymentAssetRate.coefficient=100000000&asset_rates_hint.paymentAssetRate.scale=8&asset_rates_hint.expiry_timestamp=1800000000")
-        .to_request();
-    let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
-
+    let status = resp.status();
     let json: Value = test::read_body_json(resp).await;
-    info!("Asset rates with hint response: {:?}", json);
+    assert_status_matches_body(status, &json);
 }
 
 #[actix_rt::test]
@@ -583,9 +428,10 @@ async fn test_buy_order_timeout_scenarios() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(resp_status, &json);
     // Likely to be rejected or timeout
     info!("Buy order with short timeout response: {:?}", json);
 }
@@ -655,9 +501,10 @@ async fn test_fixed_point_rate_conversion() {
         .uri("/v1/taproot-assets/rfq/quotes/peeraccepted")
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(resp_status, &json);
 
     // Check rate structure in any existing quotes
     let buy_quotes = json["buy_quotes"].as_array().unwrap();
@@ -710,7 +557,9 @@ async fn test_create_multiple_offers() {
             .set_json(&buy_request)
             .to_request();
         let buy_resp = test::call_service(&app, buy_req).await;
-        assert!(buy_resp.status().is_success());
+        let buy_status = buy_resp.status();
+        let buy_json: Value = test::read_body_json(buy_resp).await;
+        assert_status_matches_body(buy_status, &buy_json);
 
         // Sell offer
         let sell_request = SellOfferRequest {
@@ -727,7 +576,9 @@ async fn test_create_multiple_offers() {
             .set_json(&sell_request)
             .to_request();
         let sell_resp = test::call_service(&app, sell_req).await;
-        assert!(sell_resp.status().is_success());
+        let sell_status = sell_resp.status();
+        let sell_json: Value = test::read_body_json(sell_resp).await;
+        assert_status_matches_body(sell_status, &sell_json);
     }
 
     info!("Successfully created multiple buy and sell offers");
@@ -750,9 +601,10 @@ async fn test_quote_expiry_validation() {
         .uri("/v1/taproot-assets/rfq/quotes/peeraccepted")
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(resp_status, &json);
     let current_time = chrono::Utc::now().timestamp() as u64;
 
     // Check buy quotes expiry
@@ -807,9 +659,10 @@ async fn test_min_transportable_units() {
         .uri("/v1/taproot-assets/rfq/quotes/peeraccepted")
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(resp_status, &json);
 
     // Check buy quotes min transportable units
     let buy_quotes = json["buy_quotes"].as_array().unwrap();

--- a/tests/rfq.rs
+++ b/tests/rfq.rs
@@ -6,7 +6,9 @@ use taproot_assets_rest_gateway::api::rfq::{
     SellOfferRequest, SellOrderRequest, VerifyAcceptQuoteRequest,
 };
 use taproot_assets_rest_gateway::api::routes::configure;
-use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup, setup_without_assets};
+use taproot_assets_rest_gateway::tests::setup::{
+    assert_status_matches_body, mint_test_asset, setup, setup_without_assets,
+};
 use tracing::info;
 
 #[actix_rt::test]
@@ -144,7 +146,7 @@ async fn test_submit_buy_order() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     info!("Buy order response: {:?}", json);
 
     // Check if it's an error response first
@@ -221,7 +223,7 @@ async fn test_submit_sell_order() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     info!("Sell order response: {:?}", json);
 
     // Check if it's an error response first

--- a/tests/rfq.rs
+++ b/tests/rfq.rs
@@ -2,7 +2,8 @@ use actix_web::{test, App};
 use serde_json::{json, Value};
 use serial_test::serial;
 use taproot_assets_rest_gateway::api::rfq::{
-    BuyOfferRequest, BuyOrderRequest, SellOfferRequest, SellOrderRequest,
+    BuyOfferRequest, BuyOrderRequest, QueryAssetRatesRequest, ResolveRequestRequest,
+    SellOfferRequest, SellOrderRequest, VerifyAcceptQuoteRequest,
 };
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup, setup_without_assets};
@@ -331,6 +332,105 @@ async fn test_get_asset_rates() {
         assert!(error_resp["message"].is_string());
         assert!(error_resp["code"].is_number());
     }
+}
+
+#[actix_rt::test]
+async fn test_portfoliopilot_query_asset_rates() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    info!("Testing portfoliopilot query asset rates");
+
+    let request = QueryAssetRatesRequest {
+        asset_specifier: Some(json!({
+            "asset_id_str": "0000000000000000000000000000000000000000000000000000000000000001"
+        })),
+        direction: None,
+        intent: None,
+        asset_amount: Some("1000".to_string()),
+        payment_amount: None,
+        asset_rate_hint: None,
+        price_oracle_metadata: None,
+        peer_id: None,
+        expiry_timestamp: None,
+    };
+
+    let req = test::TestRequest::post()
+        .uri("/v1/taproot-assets/rfq/portfoliopilot/assetrates")
+        .set_json(&request)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let json: Value = test::read_body_json(resp).await;
+    info!("Portfoliopilot asset rates response: {:?}", json);
+    assert!(json.is_object());
+}
+
+#[actix_rt::test]
+async fn test_portfoliopilot_resolve_request() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    info!("Testing portfoliopilot resolve request");
+
+    let request = ResolveRequestRequest {
+        buy_request: None,
+        sell_request: None,
+    };
+
+    let req = test::TestRequest::post()
+        .uri("/v1/taproot-assets/rfq/portfoliopilot/resolve")
+        .set_json(&request)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let json: Value = test::read_body_json(resp).await;
+    info!("Portfoliopilot resolve response: {:?}", json);
+    assert!(json.is_object());
+}
+
+#[actix_rt::test]
+async fn test_portfoliopilot_verify_accept_quote() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    info!("Testing portfoliopilot verify accept quote");
+
+    let request = VerifyAcceptQuoteRequest { accept: json!({}) };
+
+    let req = test::TestRequest::post()
+        .uri("/v1/taproot-assets/rfq/portfoliopilot/verify")
+        .set_json(&request)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let json: Value = test::read_body_json(resp).await;
+    info!("Portfoliopilot verify response: {:?}", json);
+    assert!(json.is_object());
 }
 
 #[actix_rt::test]

--- a/tests/rfq.rs
+++ b/tests/rfq.rs
@@ -141,9 +141,10 @@ async fn test_submit_buy_order() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     info!("Buy order response: {:?}", json);
 
     // Check if it's an error response first
@@ -217,9 +218,10 @@ async fn test_submit_sell_order() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     info!("Sell order response: {:?}", json);
 
     // Check if it's an error response first

--- a/tests/send.rs
+++ b/tests/send.rs
@@ -43,8 +43,9 @@ async fn test_send_assets_basic() {
             .to_request(),
     )
     .await;
-    assert!(addr_resp.status().is_success());
+    let addr_resp_status = addr_resp.status();
     let addr_json: Value = test::read_body_json(addr_resp).await;
+    assert!(addr_resp_status.is_success() || addr_json.get("error").is_some());
     if addr_json.get("error").is_some() || addr_json.get("code").is_some() {
         println!("Address creation failed: {addr_json:?}");
         return;
@@ -61,8 +62,9 @@ async fn test_send_assets_basic() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
     let send_json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || send_json.get("error").is_some());
     if send_json.get("error").is_some() || send_json.get("code").is_some() {
         println!("Send failed with error: {send_json:?}");
         return;
@@ -112,8 +114,9 @@ async fn test_send_with_custom_fee_rate() {
             .to_request(),
     )
     .await;
-    assert!(addr_resp.status().is_success());
+    let addr_resp_status = addr_resp.status();
     let addr_json: Value = test::read_body_json(addr_resp).await;
+    assert!(addr_resp_status.is_success() || addr_json.get("error").is_some());
     if addr_json.get("error").is_some() || addr_json.get("code").is_some() {
         println!("Address creation failed: {addr_json:?}");
         return;
@@ -134,8 +137,9 @@ async fn test_send_with_custom_fee_rate() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
     let send_json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || send_json.get("error").is_some());
     if send_json.get("error").is_some() || send_json.get("code").is_some() {
         println!("Send failed with error: {send_json:?}");
         return;
@@ -185,8 +189,9 @@ async fn test_send_multiple_outputs() {
                 .to_request(),
         )
         .await;
-        assert!(addr_resp.status().is_success());
+        let addr_resp_status = addr_resp.status();
         let addr_json: Value = test::read_body_json(addr_resp).await;
+        assert!(addr_resp_status.is_success() || addr_json.get("error").is_some());
         if addr_json.get("error").is_some() || addr_json.get("code").is_some() {
             println!("Address creation failed: {addr_json:?}");
             continue;
@@ -269,8 +274,9 @@ async fn test_send_with_proof_courier() {
             .to_request(),
     )
     .await;
-    assert!(addr_resp.status().is_success());
+    let addr_resp_status = addr_resp.status();
     let addr_json: Value = test::read_body_json(addr_resp).await;
+    assert!(addr_resp_status.is_success() || addr_json.get("error").is_some());
     // Check for errors first
     if addr_json.get("error").is_some() || addr_json.get("code").is_some() {
         println!("Address creation failed: {addr_json:?}");
@@ -322,8 +328,9 @@ async fn test_send_validation_errors() {
         .set_json(&empty_request)
         .to_request();
     let empty_resp = test::call_service(&app, empty_req).await;
-    assert!(empty_resp.status().is_success());
+    let empty_resp_status = empty_resp.status();
     let empty_json: Value = test::read_body_json(empty_resp).await;
+    assert!(empty_resp_status.is_success() || empty_json.get("error").is_some());
     if empty_json.get("error").is_some() || empty_json.get("code").is_some() {
         println!("Empty address error: {empty_json:?}");
     } else {
@@ -398,8 +405,9 @@ async fn test_send_response_structure() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
     let send_json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || send_json.get("error").is_some());
     if send_json.get("error").is_some() || send_json.get("code").is_some() {
         println!("Send failed with error: {send_json:?}");
         return;

--- a/tests/send.rs
+++ b/tests/send.rs
@@ -4,7 +4,9 @@ use serial_test::serial;
 use taproot_assets_rest_gateway::api::addresses::NewAddrRequest;
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::api::send::SendRequest;
-use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup};
+use taproot_assets_rest_gateway::tests::setup::{
+    assert_status_matches_body, mint_test_asset, setup,
+};
 
 #[actix_rt::test]
 #[serial]
@@ -45,7 +47,7 @@ async fn test_send_assets_basic() {
     .await;
     let addr_resp_status = addr_resp.status();
     let addr_json: Value = test::read_body_json(addr_resp).await;
-    assert!(addr_resp_status.is_success() || addr_json.get("error").is_some());
+    assert_status_matches_body(addr_resp_status, &addr_json);
     if addr_json.get("error").is_some() || addr_json.get("code").is_some() {
         println!("Address creation failed: {addr_json:?}");
         return;
@@ -64,7 +66,7 @@ async fn test_send_assets_basic() {
     let resp = test::call_service(&app, req).await;
     let resp_status = resp.status();
     let send_json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || send_json.get("error").is_some());
+    assert_status_matches_body(resp_status, &send_json);
     if send_json.get("error").is_some() || send_json.get("code").is_some() {
         println!("Send failed with error: {send_json:?}");
         return;
@@ -116,7 +118,7 @@ async fn test_send_with_custom_fee_rate() {
     .await;
     let addr_resp_status = addr_resp.status();
     let addr_json: Value = test::read_body_json(addr_resp).await;
-    assert!(addr_resp_status.is_success() || addr_json.get("error").is_some());
+    assert_status_matches_body(addr_resp_status, &addr_json);
     if addr_json.get("error").is_some() || addr_json.get("code").is_some() {
         println!("Address creation failed: {addr_json:?}");
         return;
@@ -139,7 +141,7 @@ async fn test_send_with_custom_fee_rate() {
     let resp = test::call_service(&app, req).await;
     let resp_status = resp.status();
     let send_json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || send_json.get("error").is_some());
+    assert_status_matches_body(resp_status, &send_json);
     if send_json.get("error").is_some() || send_json.get("code").is_some() {
         println!("Send failed with error: {send_json:?}");
         return;
@@ -191,7 +193,7 @@ async fn test_send_multiple_outputs() {
         .await;
         let addr_resp_status = addr_resp.status();
         let addr_json: Value = test::read_body_json(addr_resp).await;
-        assert!(addr_resp_status.is_success() || addr_json.get("error").is_some());
+        assert_status_matches_body(addr_resp_status, &addr_json);
         if addr_json.get("error").is_some() || addr_json.get("code").is_some() {
             println!("Address creation failed: {addr_json:?}");
             continue;
@@ -276,7 +278,7 @@ async fn test_send_with_proof_courier() {
     .await;
     let addr_resp_status = addr_resp.status();
     let addr_json: Value = test::read_body_json(addr_resp).await;
-    assert!(addr_resp_status.is_success() || addr_json.get("error").is_some());
+    assert_status_matches_body(addr_resp_status, &addr_json);
     // Check for errors first
     if addr_json.get("error").is_some() || addr_json.get("code").is_some() {
         println!("Address creation failed: {addr_json:?}");
@@ -330,7 +332,7 @@ async fn test_send_validation_errors() {
     let empty_resp = test::call_service(&app, empty_req).await;
     let empty_resp_status = empty_resp.status();
     let empty_json: Value = test::read_body_json(empty_resp).await;
-    assert!(empty_resp_status.is_success() || empty_json.get("error").is_some());
+    assert_status_matches_body(empty_resp_status, &empty_json);
     if empty_json.get("error").is_some() || empty_json.get("code").is_some() {
         println!("Empty address error: {empty_json:?}");
     } else {
@@ -407,7 +409,7 @@ async fn test_send_response_structure() {
     let resp = test::call_service(&app, req).await;
     let resp_status = resp.status();
     let send_json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || send_json.get("error").is_some());
+    assert_status_matches_body(resp_status, &send_json);
     if send_json.get("error").is_some() || send_json.get("code").is_some() {
         println!("Send failed with error: {send_json:?}");
         return;

--- a/tests/ui_specific.rs
+++ b/tests/ui_specific.rs
@@ -3,7 +3,9 @@ use serde_json::{json, Value};
 use serial_test::serial;
 use std::time::Duration;
 use taproot_assets_rest_gateway::api::routes::configure;
-use taproot_assets_rest_gateway::tests::setup::{setup, setup_without_assets};
+use taproot_assets_rest_gateway::tests::setup::{
+    assert_status_matches_body, setup, setup_without_assets,
+};
 use tokio::time::{sleep, timeout};
 use tracing::info;
 
@@ -476,7 +478,7 @@ async fn test_confirmation_dialog_data() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     if json.get("error").is_none() && json.get("code").is_none() {
         assert!(json["burn_transfer"].is_object() || json["transfer"].is_object());
         info!("Burn confirmation dialog should show transfer details");

--- a/tests/ui_specific.rs
+++ b/tests/ui_specific.rs
@@ -463,7 +463,7 @@ async fn test_confirmation_dialog_data() {
     .await;
 
     let burn_req = json!({
-        "asset_id": asset_id,
+        "asset_specifier": { "asset_id_str": asset_id },
         "amount_to_burn": "10",
         "confirmation_text": "assets will be destroyed"
     });

--- a/tests/ui_specific.rs
+++ b/tests/ui_specific.rs
@@ -473,9 +473,10 @@ async fn test_confirmation_dialog_data() {
         .set_json(&burn_req)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     if json.get("error").is_none() && json.get("code").is_none() {
         assert!(json["burn_transfer"].is_object() || json["transfer"].is_object());
         info!("Burn confirmation dialog should show transfer details");

--- a/tests/universe.rs
+++ b/tests/universe.rs
@@ -35,14 +35,9 @@ async fn test_add_federation_server() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-
-    // May fail if server is unreachable, but API structure should be correct
-    assert!(resp.status().is_success() || resp.status().is_client_error());
-
-    if resp.status().is_success() {
-        let json: Value = test::read_body_json(resp).await;
-        println!("Add federation response: {json:?}");
-    }
+    let status = resp.status();
+    let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &json);
 }
 
 #[actix_rt::test]
@@ -164,13 +159,11 @@ async fn test_sync_with_universe() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &json);
 
-    // May fail if no assets to sync, but API structure should be correct
-    assert!(resp.status().is_success() || resp.status().is_client_error());
-
-    if resp.status().is_success() {
-        let json: Value = test::read_body_json(resp).await;
-        // Response might have synced_universes or an error/empty response
+    if status.is_success() {
         if let Some(synced) = json.get("synced_universes") {
             assert!(synced.is_array() || synced.is_object());
         }
@@ -213,7 +206,9 @@ async fn test_sync_with_specific_assets() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success() || resp.status().is_client_error());
+    let status = resp.status();
+    let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &json);
 }
 
 #[actix_rt::test]
@@ -273,9 +268,10 @@ async fn test_query_asset_roots() {
         ))
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &json);
 
     // Should have issuance and transfer roots
     if json["issuance_root"].is_object() {
@@ -496,9 +492,9 @@ async fn test_delete_universe_root() {
         }))
         .to_request();
     let resp = test::call_service(&app, req).await;
-
-    // Expect this to fail as the asset doesn't exist
-    assert!(resp.status().is_success() || resp.status().is_client_error());
+    let status = resp.status();
+    let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &json);
 }
 
 #[actix_rt::test]
@@ -866,7 +862,9 @@ async fn test_sync_modes() {
             .to_request(),
     )
     .await;
-    assert!(issuance_resp.status().is_success() || issuance_resp.status().is_client_error());
+    let issuance_status = issuance_resp.status();
+    let issuance_json: Value = test::read_body_json(issuance_resp).await;
+    assert_status_matches_body(issuance_status, &issuance_json);
 
     // Test SYNC_FULL mode
     let full_request = SyncRequest {
@@ -883,7 +881,9 @@ async fn test_sync_modes() {
             .to_request(),
     )
     .await;
-    assert!(full_resp.status().is_success() || full_resp.status().is_client_error());
+    let full_status = full_resp.status();
+    let full_json: Value = test::read_body_json(full_resp).await;
+    assert_status_matches_body(full_status, &full_json);
 }
 
 #[actix_rt::test]

--- a/tests/universe.rs
+++ b/tests/universe.rs
@@ -1,4 +1,4 @@
-use actix_web::{test, App};
+use actix_web::{http::StatusCode, test, App};
 use serde_json::{json, Value};
 use serial_test::serial;
 use taproot_assets_rest_gateway::api::routes::configure;
@@ -6,7 +6,9 @@ use taproot_assets_rest_gateway::api::universe::{
     FederationRequest, IgnoreAssetOutPointRequest, InsertSupplyCommitRequest, MultiverseRequest,
     PushProofRequest, SyncConfigRequest, SyncRequest, UpdateSupplyCommitRequest,
 };
-use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup, setup_without_assets};
+use taproot_assets_rest_gateway::tests::setup::{
+    assert_status_matches_body, mint_test_asset, setup, setup_without_assets,
+};
 use tokio::time::{sleep, Duration};
 
 #[actix_rt::test]
@@ -669,7 +671,7 @@ async fn test_get_asset_keys() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
 
     // Check if we got an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -907,7 +909,7 @@ async fn test_fetch_supply_commit() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Fetch supply commit returned error: {json:?}");
     } else {
@@ -946,7 +948,7 @@ async fn test_insert_supply_commit() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Insert supply commit returned error: {json:?}");
     } else {
@@ -987,7 +989,7 @@ async fn test_ignore_asset_outpoint() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Ignore asset outpoint returned error: {json:?}");
     } else {
@@ -1018,7 +1020,7 @@ async fn test_fetch_supply_leaves() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Fetch supply leaves returned error: {json:?}");
     } else {
@@ -1054,7 +1056,7 @@ async fn test_update_supply_commit() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Update supply commit returned error: {json:?}");
     } else {
@@ -1078,5 +1080,15 @@ async fn test_fetch_supply_commit_invalid_group_key() {
         .uri("/v1/taproot-assets/universe/supply/not-hex")
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_client_error());
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    // A hex string of the wrong length is rejected before any upstream call.
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/v1/taproot-assets/universe/supply/{}",
+            "a".repeat(65)
+        ))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }

--- a/tests/universe.rs
+++ b/tests/universe.rs
@@ -3,7 +3,8 @@ use serde_json::{json, Value};
 use serial_test::serial;
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::api::universe::{
-    FederationRequest, MultiverseRequest, PushProofRequest, SyncConfigRequest, SyncRequest,
+    FederationRequest, IgnoreAssetOutPointRequest, InsertSupplyCommitRequest, MultiverseRequest,
+    PushProofRequest, SyncConfigRequest, SyncRequest, UpdateSupplyCommitRequest,
 };
 use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup, setup_without_assets};
 use tokio::time::{sleep, Duration};
@@ -880,4 +881,196 @@ async fn test_sync_modes() {
     )
     .await;
     assert!(full_resp.status().is_success() || full_resp.status().is_client_error());
+}
+
+#[actix_rt::test]
+async fn test_fetch_supply_commit() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    let group_key = format!("02{}", "0".repeat(64));
+
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/v1/taproot-assets/universe/supply/{group_key}?latest=true"
+        ))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let json: Value = test::read_body_json(resp).await;
+    if json.get("error").is_some() || json.get("code").is_some() {
+        println!("Fetch supply commit returned error: {json:?}");
+    } else {
+        assert!(json.is_object());
+    }
+}
+
+#[actix_rt::test]
+async fn test_insert_supply_commit() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    let group_key = format!("02{}", "0".repeat(64));
+
+    let request = InsertSupplyCommitRequest {
+        group_key_bytes: None,
+        chain_data: None,
+        spent_commitment_outpoint: None,
+        issuance_leaves: None,
+        burn_leaves: None,
+        ignore_leaves: None,
+    };
+
+    let req = test::TestRequest::post()
+        .uri(&format!("/v1/taproot-assets/universe/supply/{group_key}"))
+        .set_json(&request)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let json: Value = test::read_body_json(resp).await;
+    if json.get("error").is_some() || json.get("code").is_some() {
+        println!("Insert supply commit returned error: {json:?}");
+    } else {
+        assert!(json.is_object());
+    }
+}
+
+#[actix_rt::test]
+async fn test_ignore_asset_outpoint() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    let request = IgnoreAssetOutPointRequest {
+        asset_out_point: json!({
+            "asset_id": "0000000000000000000000000000000000000000000000000000000000000001",
+            "anchor_out_point": {
+                "txid": "0000000000000000000000000000000000000000000000000000000000000000",
+                "output_index": 0
+            }
+        }),
+        amount: Some("1".to_string()),
+    };
+
+    // The static /supply/ignore route must match, not the /supply/{group_key_str} param
+    // route (which would reject "ignore" as an invalid hex path parameter).
+    let req = test::TestRequest::post()
+        .uri("/v1/taproot-assets/universe/supply/ignore")
+        .set_json(&request)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let json: Value = test::read_body_json(resp).await;
+    if json.get("error").is_some() || json.get("code").is_some() {
+        println!("Ignore asset outpoint returned error: {json:?}");
+    } else {
+        assert!(json.is_object());
+    }
+}
+
+#[actix_rt::test]
+async fn test_fetch_supply_leaves() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    let group_key = format!("02{}", "0".repeat(64));
+
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/v1/taproot-assets/universe/supply/leaves/{group_key}?block_height_start=0"
+        ))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let json: Value = test::read_body_json(resp).await;
+    if json.get("error").is_some() || json.get("code").is_some() {
+        println!("Fetch supply leaves returned error: {json:?}");
+    } else {
+        assert!(json.is_object());
+    }
+}
+
+#[actix_rt::test]
+async fn test_update_supply_commit() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    let group_key = format!("02{}", "0".repeat(64));
+
+    let request = UpdateSupplyCommitRequest {
+        group_key_bytes: None,
+    };
+
+    let req = test::TestRequest::post()
+        .uri(&format!(
+            "/v1/taproot-assets/universe/supply/update/{group_key}"
+        ))
+        .set_json(&request)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let json: Value = test::read_body_json(resp).await;
+    if json.get("error").is_some() || json.get("code").is_some() {
+        println!("Update supply commit returned error: {json:?}");
+    } else {
+        assert!(json.is_object());
+    }
+}
+
+#[actix_rt::test]
+async fn test_fetch_supply_commit_invalid_group_key() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/v1/taproot-assets/universe/supply/not-hex")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_client_error());
 }

--- a/tests/universe.rs
+++ b/tests/universe.rs
@@ -666,9 +666,10 @@ async fn test_get_asset_keys() {
         ))
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
 
     // Check if we got an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -903,9 +904,10 @@ async fn test_fetch_supply_commit() {
         ))
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Fetch supply commit returned error: {json:?}");
     } else {
@@ -941,9 +943,10 @@ async fn test_insert_supply_commit() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Insert supply commit returned error: {json:?}");
     } else {
@@ -981,9 +984,10 @@ async fn test_ignore_asset_outpoint() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Ignore asset outpoint returned error: {json:?}");
     } else {
@@ -1011,9 +1015,10 @@ async fn test_fetch_supply_leaves() {
         ))
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Fetch supply leaves returned error: {json:?}");
     } else {
@@ -1046,9 +1051,10 @@ async fn test_update_supply_commit() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
     if json.get("error").is_some() || json.get("code").is_some() {
         println!("Update supply commit returned error: {json:?}");
     } else {

--- a/tests/universe_integration.rs
+++ b/tests/universe_integration.rs
@@ -162,8 +162,9 @@ async fn test_complete_universe_workflow() {
                 .to_request(),
         )
         .await;
-        assert!(roots_resp.status().is_success());
+        let roots_resp_status = roots_resp.status();
         let roots_json: Value = test::read_body_json(roots_resp).await;
+        assert!(roots_resp_status.is_success() || roots_json.get("error").is_some());
 
         if roots_json.get("error").is_some() || roots_json.get("code").is_some() {
             info!("Asset roots query returned error: {:?}", roots_json);
@@ -184,8 +185,9 @@ async fn test_complete_universe_workflow() {
                 .to_request(),
         )
         .await;
-        assert!(leaves_resp.status().is_success());
+        let leaves_resp_status = leaves_resp.status();
         let leaves_json: Value = test::read_body_json(leaves_resp).await;
+        assert!(leaves_resp_status.is_success() || leaves_json.get("error").is_some());
 
         if leaves_json.get("error").is_some() || leaves_json.get("code").is_some() {
             info!("Asset leaves query returned error: {:?}", leaves_json);

--- a/tests/universe_integration.rs
+++ b/tests/universe_integration.rs
@@ -5,7 +5,9 @@ use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::api::universe::{
     FederationRequest, SyncConfigRequest, SyncRequest,
 };
-use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup, setup_without_assets};
+use taproot_assets_rest_gateway::tests::setup::{
+    assert_status_matches_body, mint_test_asset, setup, setup_without_assets,
+};
 use tokio::time::{sleep, Duration};
 use tracing::info;
 
@@ -164,7 +166,7 @@ async fn test_complete_universe_workflow() {
         .await;
         let roots_resp_status = roots_resp.status();
         let roots_json: Value = test::read_body_json(roots_resp).await;
-        assert!(roots_resp_status.is_success() || roots_json.get("error").is_some());
+        assert_status_matches_body(roots_resp_status, &roots_json);
 
         if roots_json.get("error").is_some() || roots_json.get("code").is_some() {
             info!("Asset roots query returned error: {:?}", roots_json);
@@ -187,7 +189,7 @@ async fn test_complete_universe_workflow() {
         .await;
         let leaves_resp_status = leaves_resp.status();
         let leaves_json: Value = test::read_body_json(leaves_resp).await;
-        assert!(leaves_resp_status.is_success() || leaves_json.get("error").is_some());
+        assert_status_matches_body(leaves_resp_status, &leaves_json);
 
         if leaves_json.get("error").is_some() || leaves_json.get("code").is_some() {
             info!("Asset leaves query returned error: {:?}", leaves_json);

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -7,7 +7,9 @@ use taproot_assets_rest_gateway::api::wallet::{
     ExportBackupRequest, ImportBackupRequest, InternalKeyRequest, OwnershipProveRequest,
     OwnershipVerifyRequest, ScriptKeyRequest, UtxoLeaseDeleteRequest,
 };
-use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup, setup_without_assets};
+use taproot_assets_rest_gateway::tests::setup::{
+    assert_status_matches_body, mint_test_asset, setup, setup_without_assets,
+};
 
 #[actix_rt::test]
 async fn test_generate_next_internal_key() {
@@ -77,7 +79,7 @@ async fn test_query_internal_key() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
 
     // Check if it's an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -158,7 +160,7 @@ async fn test_query_script_key() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
 
     // Check if it's an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -208,7 +210,7 @@ async fn test_declare_script_key() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
 
     // Check if it's an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -287,7 +289,7 @@ async fn test_prove_asset_ownership() {
                 let resp_status = resp.status();
 
                 let json: Value = test::read_body_json(resp).await;
-                assert!(resp_status.is_success() || json.get("error").is_some());
+                assert_status_matches_body(resp_status, &json);
 
                 // Check if it's an error response
                 if json.get("error").is_some() || json.get("code").is_some() {
@@ -389,7 +391,7 @@ async fn test_verify_ownership_proof() {
                     let resp_status = resp.status();
 
                     let json: Value = test::read_body_json(resp).await;
-                    assert!(resp_status.is_success() || json.get("error").is_some());
+                    assert_status_matches_body(resp_status, &json);
 
                     // Check if it's an error response
                     if json.get("error").is_some() || json.get("code").is_some() {
@@ -437,7 +439,7 @@ async fn test_delete_utxo_lease() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
 
     // Check if it's an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -475,7 +477,7 @@ async fn test_key_family_ranges() {
         let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
-        assert!(resp_status.is_success() || json.get("error").is_some());
+        assert_status_matches_body(resp_status, &json);
 
         // Check if it's an error response
         if json.get("error").is_some() || json.get("code").is_some() {
@@ -616,7 +618,7 @@ async fn test_ownership_proof_with_invalid_challenge() {
                     let resp_status = resp.status();
 
                     let json: Value = test::read_body_json(resp).await;
-                    assert!(resp_status.is_success() || json.get("error").is_some());
+                    assert_status_matches_body(resp_status, &json);
 
                     // Should either return an error or valid_proof=false
                     if json.get("error").is_none() && json.get("code").is_none() {
@@ -650,7 +652,7 @@ async fn test_export_asset_wallet_backup() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
 
     // Check if it's an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -687,7 +689,7 @@ async fn test_import_assets_from_backup() {
     let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
-    assert!(resp_status.is_success() || json.get("error").is_some());
+    assert_status_matches_body(resp_status, &json);
 
     // Check if it's an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -742,7 +744,7 @@ async fn test_declare_multiple_script_keys() {
         let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
-        assert!(resp_status.is_success() || json.get("error").is_some());
+        assert_status_matches_body(resp_status, &json);
         if json.get("error").is_some() || json.get("code").is_some() {
             println!("Declare script key type {key_type} returned error: {json:?}");
         }

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -74,9 +74,10 @@ async fn test_query_internal_key() {
     let resp = test::call_service(&app, req).await;
 
     // The API returns 200 OK with an error in the response body if key not found
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
 
     // Check if it's an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -154,9 +155,10 @@ async fn test_query_script_key() {
     let resp = test::call_service(&app, req).await;
 
     // The API returns 200 OK with an error in the response body if key not found
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
 
     // Check if it's an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -203,9 +205,10 @@ async fn test_declare_script_key() {
     let resp = test::call_service(&app, req).await;
 
     // The API returns 200 OK even for errors
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
 
     // Check if it's an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -281,9 +284,10 @@ async fn test_prove_asset_ownership() {
                     .set_json(&request)
                     .to_request();
                 let resp = test::call_service(&app, req).await;
-                assert!(resp.status().is_success());
+                let resp_status = resp.status();
 
                 let json: Value = test::read_body_json(resp).await;
+                assert!(resp_status.is_success() || json.get("error").is_some());
 
                 // Check if it's an error response
                 if json.get("error").is_some() || json.get("code").is_some() {
@@ -382,9 +386,10 @@ async fn test_verify_ownership_proof() {
                         .set_json(&verify_request)
                         .to_request();
                     let resp = test::call_service(&app, req).await;
-                    assert!(resp.status().is_success());
+                    let resp_status = resp.status();
 
                     let json: Value = test::read_body_json(resp).await;
+                    assert!(resp_status.is_success() || json.get("error").is_some());
 
                     // Check if it's an error response
                     if json.get("error").is_some() || json.get("code").is_some() {
@@ -429,9 +434,10 @@ async fn test_delete_utxo_lease() {
     let resp = test::call_service(&app, req).await;
 
     // The API returns 200 OK even for errors
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
 
     // Check if it's an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -466,9 +472,10 @@ async fn test_key_family_ranges() {
             .set_json(&request)
             .to_request();
         let resp = test::call_service(&app, req).await;
-        assert!(resp.status().is_success());
+        let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
+        assert!(resp_status.is_success() || json.get("error").is_some());
 
         // Check if it's an error response
         if json.get("error").is_some() || json.get("code").is_some() {
@@ -606,9 +613,10 @@ async fn test_ownership_proof_with_invalid_challenge() {
                         .set_json(&verify_request)
                         .to_request();
                     let resp = test::call_service(&app, req).await;
-                    assert!(resp.status().is_success());
+                    let resp_status = resp.status();
 
                     let json: Value = test::read_body_json(resp).await;
+                    assert!(resp_status.is_success() || json.get("error").is_some());
 
                     // Should either return an error or valid_proof=false
                     if json.get("error").is_none() && json.get("code").is_none() {
@@ -639,9 +647,10 @@ async fn test_export_asset_wallet_backup() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
 
     // Check if it's an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -675,9 +684,10 @@ async fn test_import_assets_from_backup() {
     let resp = test::call_service(&app, req).await;
 
     // The API returns 200 OK even for errors
-    assert!(resp.status().is_success());
+    let resp_status = resp.status();
 
     let json: Value = test::read_body_json(resp).await;
+    assert!(resp_status.is_success() || json.get("error").is_some());
 
     // Check if it's an error response
     if json.get("error").is_some() || json.get("code").is_some() {
@@ -729,9 +739,10 @@ async fn test_declare_multiple_script_keys() {
         let resp = test::call_service(&app, req).await;
 
         // API returns 200 OK even for errors
-        assert!(resp.status().is_success());
+        let resp_status = resp.status();
 
         let json: Value = test::read_body_json(resp).await;
+        assert!(resp_status.is_success() || json.get("error").is_some());
         if json.get("error").is_some() || json.get("code").is_some() {
             println!("Declare script key type {key_type} returned error: {json:?}");
         }

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -675,8 +675,9 @@ async fn test_import_assets_from_backup() {
     )
     .await;
 
+    // tapd encodes protobuf `bytes` fields as hex, not base64.
     let request = ImportBackupRequest {
-        backup: base64::engine::general_purpose::STANDARD.encode(b"invalid backup"),
+        backup: hex::encode(b"invalid backup"),
     };
 
     let req = test::TestRequest::post()

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -4,8 +4,8 @@ use serde_json::{json, Value};
 use serial_test::serial;
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::api::wallet::{
-    InternalKeyRequest, OwnershipProveRequest, OwnershipVerifyRequest, ScriptKeyRequest,
-    UtxoLeaseDeleteRequest,
+    ExportBackupRequest, ImportBackupRequest, InternalKeyRequest, OwnershipProveRequest,
+    OwnershipVerifyRequest, ScriptKeyRequest, UtxoLeaseDeleteRequest,
 };
 use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup, setup_without_assets};
 
@@ -617,6 +617,74 @@ async fn test_ownership_proof_with_invalid_challenge() {
                 }
             }
         }
+    }
+}
+
+#[actix_rt::test]
+async fn test_export_asset_wallet_backup() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    let request = ExportBackupRequest { mode: None };
+
+    let req = test::TestRequest::post()
+        .uri("/v1/taproot-assets/wallet/backup/export")
+        .set_json(&request)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let json: Value = test::read_body_json(resp).await;
+
+    // Check if it's an error response
+    if json.get("error").is_some() || json.get("code").is_some() {
+        println!("Export wallet backup returned error: {json:?}");
+        // This is expected if the daemon has no assets to back up
+    } else {
+        assert!(json.is_object());
+    }
+}
+
+#[actix_rt::test]
+async fn test_import_assets_from_backup() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    let request = ImportBackupRequest {
+        backup: base64::engine::general_purpose::STANDARD.encode(b"invalid backup"),
+    };
+
+    let req = test::TestRequest::post()
+        .uri("/v1/taproot-assets/wallet/backup/import")
+        .set_json(&request)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    // The API returns 200 OK even for errors
+    assert!(resp.status().is_success());
+
+    let json: Value = test::read_body_json(resp).await;
+
+    // Check if it's an error response
+    if json.get("error").is_some() || json.get("code").is_some() {
+        println!("Import assets from backup returned error: {json:?}");
+        // This is expected for an invalid backup payload
+    } else {
+        assert!(json.is_object());
     }
 }
 


### PR DESCRIPTION
Adds the REST endpoints introduced in tapd 0.8, and corrects error handling that made every upstream failure look like a success.

## Endpoints added

- `GET/POST /universe/supply/{group_key_str}`, `POST /universe/supply/ignore`, `GET /universe/supply/leaves/{group_key_str}`, `POST /universe/supply/update/{group_key_str}`
- `POST /wallet/backup/export`, `POST /wallet/backup/import`
- `POST /mailbox/remove`

## Endpoints removed

- `POST /rfq/portfoliopilot/{assetrates,resolve,verify}`
- `GET /rfq/priceoracle/assetrates`

tapd never serves these. Its REST proxy registers only the TaprootAssets, AssetWallet, Mint, Rfq, TaprootAssetChannels and Universe handlers. `PriceOracle` and `PortfolioPilot` are interfaces tapd acts as a *client* of, pointed at an external server via `--experimental.rfq.priceoracleaddress` / `--experimental.rfq.portfoliopilotaddress`. Proxying them to tapd returns 404 on every version. Their swagger files and the published API docs render REST paths because the protos carry `google.api.http` annotations describing the contract a third-party server implements, not tapd's served surface.

## Behavior changes

- Upstream status codes now propagate. Handlers previously called `.json()` without inspecting `response.status()`, so a tapd 4xx/5xx reached the client as `200 OK` with the error in the body. For `burn` and `backup/import` a caller could not distinguish success from rejection. tapd's error document is relayed verbatim, so existing `code` / `message` fields are unchanged; only the status is corrected.
- The gateway refuses to start when `API_KEY` is unset. It proxies destructive and secret-exposing endpoints, including whole-wallet backup export. Set `ALLOW_INSECURE_NO_AUTH=true` to override in development.
- `mode` is typed as the `RAW` / `COMPACT` / `OPTIMISTIC` enum, and `message_ids` as `u64`, rather than untyped JSON.

## Requirements

Requires **tapd 0.8.0** or newer; run gateway `v0.2.x` against tapd 0.7.x. Version bumped to `v0.3.0`.

## Verification

Unit tests grow from 76 to 92 and are the first CI-runnable coverage of these paths. Against a live tapd 0.8.0 regtest node the integration suite passes 72/1, versus a 64/2 baseline on `main`; the single remaining failure is an order-dependent flake that also fails on `main`.

Protobuf `bytes` fields are hex-encoded, not base64, matching tapd's marshaler.
