### PR TITLE
Point changelog at GitHub releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,7 +32,6 @@ Fixes #(issue)
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have run `cargo fmt` and `cargo clippy`
-- [ ] I have updated the CHANGELOG.md if applicable
 - [ ] I have tested my changes with both `TLS_VERIFY=true` and `TLS_VERIFY=false`
 
 ## Screenshots (if applicable)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,42 +1,4 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-## [0.0.1] - 2025-01-02
-
-### Added
-- Initial release of Taproot Assets REST API Proxy
-- Complete coverage of Taproot Assets API endpoints
-- Automatic macaroon authentication handling
-- Configurable CORS support for web applications
-- Request ID tracking and logging
-- Comprehensive error handling with meaningful messages
-- Environment-based configuration
-- Health and readiness check endpoints
-- Support for all asset operations (mint, transfer, burn)
-- Address generation and decoding
-- Channel funding and Lightning payments
-- Universe/federation synchronization
-- Wallet operations and PSBT management
-- Request for Quote (RFQ) functionality
-- Event streaming support
-- Basic test suite
-
-### Security
-- TLS certificate verification (configurable for development)
-- Secure macaroon handling
-- Input validation on all endpoints
-- Basic rate limiting (100 requests/minute per IP)
-
-### Documentation
-- Comprehensive README with examples
-- API documentation for all endpoints
-- Contributing guidelines
-- Security policy
-- Troubleshooting guide
-- Docker deployment instructions
+Release notes are published on GitHub:
+https://github.com/privkeyio/taproot-assets-rest-gateway/releases


### PR DESCRIPTION
`CHANGELOG.md` was last updated at `v0.0.1` (2025-07-02) and never tracked v0.2.0, v0.2.1 or v0.3.0. It still advertised "Complete coverage of Taproot Assets API endpoints", which stopped being true in v0.3.0 when four endpoints tapd never served were removed.

Release notes are maintained on the GitHub releases page, so this replaces the file with a pointer rather than leaving a stale second source of truth. Also drops the "I have updated the CHANGELOG.md" item from the PR template, which asked contributors to maintain a file nobody had maintained in a year.