### PR TITLE
Hex-encode body bytes in tests, fix txid byte order, forward burns query filter

### DIFF
--- a/src/api/burn.rs
+++ b/src/api/burn.rs
@@ -1,7 +1,7 @@
 use super::{handle_result, parse_upstream, validate_asset_id, validate_group_key};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
-use actix_web::{web, HttpResponse};
+use actix_web::{web, HttpRequest, HttpResponse};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tracing::{info, instrument};
@@ -67,9 +67,14 @@ pub async fn list_burns(
     client: &Client,
     base_url: &str,
     macaroon_hex: &str,
+    query: &str,
 ) -> Result<serde_json::Value, AppError> {
     info!("Listing burns");
-    let url = format!("{base_url}/v1/taproot-assets/burns");
+    let mut url = format!("{base_url}/v1/taproot-assets/burns");
+    if !query.is_empty() {
+        url.push('?');
+        url.push_str(query);
+    }
     let response = client
         .get(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
@@ -97,11 +102,20 @@ async fn burn(
 }
 
 async fn list(
+    req: HttpRequest,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
     macaroon_hex: web::Data<MacaroonHex>,
 ) -> HttpResponse {
-    handle_result(list_burns(client.as_ref(), &base_url.0, &macaroon_hex.0).await)
+    handle_result(
+        list_burns(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            req.query_string(),
+        )
+        .await,
+    )
 }
 
 pub fn configure(cfg: &mut web::ServiceConfig) {

--- a/src/tests/setup.rs
+++ b/src/tests/setup.rs
@@ -759,3 +759,12 @@ pub fn assert_status_matches_body(status: actix_web::http::StatusCode, body: &Va
         "status {status} disagrees with body {body}"
     );
 }
+
+/// Bitcoin txids are displayed big-endian but travel over the wire as
+/// little-endian bytes, so a txid taken from a display string must be reversed
+/// before it is hex-encoded into a protobuf `bytes` field.
+pub fn txid_to_internal_hex(display_txid: &str) -> String {
+    let mut bytes = hex::decode(display_txid).unwrap_or_default();
+    bytes.reverse();
+    hex::encode(bytes)
+}

--- a/tests/asset_creation.rs
+++ b/tests/asset_creation.rs
@@ -1,5 +1,4 @@
 use actix_web::{test, App};
-use base64::{engine::general_purpose, Engine as _};
 use serde_json::{json, Value};
 use serial_test::serial;
 use taproot_assets_rest_gateway::api::assets::{
@@ -138,7 +137,7 @@ async fn test_mint_with_metadata() {
             "name": asset_name,
             "amount": "10000",
             "asset_meta": {
-                "data": general_purpose::STANDARD.encode(metadata.to_string()),
+                "data": hex::encode(metadata.to_string()),
                 "type": "META_TYPE_JSON"
             }
         },

--- a/tests/burn.rs
+++ b/tests/burn.rs
@@ -1,4 +1,5 @@
 use actix_web::{test, App};
+use base64::{engine::general_purpose, Engine as _};
 use serde_json::Value;
 use serial_test::serial;
 use std::time::Duration;
@@ -379,7 +380,8 @@ async fn test_list_burns() {
 #[serial]
 async fn test_list_burns_with_filters() {
     let (client, base_url, macaroon_hex, lnd_macaroon_hex) = setup().await;
-    let asset_id = mint_test_asset(
+    // Ensure at least one asset exists so the daemon has burn history to filter.
+    let _asset_id = mint_test_asset(
         client.as_ref(),
         &base_url.0,
         &macaroon_hex.0,
@@ -395,25 +397,54 @@ async fn test_list_burns_with_filters() {
     )
     .await;
 
-    // Test with asset_id filter
+    // Filter against an asset that already has a burn rather than creating one:
+    // a burn needs an unlocked, confirmed on-chain UTXO, and sibling suites lease
+    // them, which made this test depend on execution order.
     let req = test::TestRequest::get()
-        .uri(&format!("/v1/taproot-assets/burns?asset_id={asset_id}"))
+        .uri("/v1/taproot-assets/burns")
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    let status = resp.status();
+    let all: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &all);
+    assert!(status.is_success());
 
+    let Some(burned_asset_id) = all["burns"]
+        .as_array()
+        .and_then(|b| b.first())
+        .and_then(|b| b["asset_id"].as_str())
+        .map(str::to_string)
+    else {
+        info!("no burns recorded yet; nothing to filter");
+        return;
+    };
+
+    // Unlike body `bytes` fields, which tapd encodes as hex, `bytes` query
+    // parameters are base64. Sending hex returns an empty list with a 200.
+    let asset_id_b64 =
+        general_purpose::STANDARD.encode(hex::decode(&burned_asset_id).expect("asset id is hex"));
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/v1/taproot-assets/burns?asset_id={}",
+            urlencoding::encode(&asset_id_b64)
+        ))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
     let json: Value = test::read_body_json(resp).await;
-    assert!(json["burns"].is_array());
+    assert_status_matches_body(status, &json);
+    assert!(status.is_success());
 
-    // Verify burn structure if any burns exist
-    if let Some(burns) = json["burns"].as_array() {
-        if !burns.is_empty() {
-            let first_burn = &burns[0];
-            assert!(first_burn["note"].is_string() || first_burn["note"].is_null());
-            assert!(first_burn["asset_id"].is_string());
-            assert!(first_burn["amount"].is_string());
-            assert!(first_burn["anchor_txid"].is_string());
-        }
+    let burns = json["burns"].as_array().expect("burns is an array");
+    assert!(
+        !burns.is_empty(),
+        "filtering by an asset that has a burn must return it"
+    );
+    for burn in burns {
+        assert_eq!(burn["asset_id"].as_str(), Some(burned_asset_id.as_str()));
+        assert!(burn["amount"].is_string());
+        assert!(burn["anchor_txid"].is_string());
+        assert!(burn["note"].is_string() || burn["note"].is_null());
     }
 }
 

--- a/tests/mailbox.rs
+++ b/tests/mailbox.rs
@@ -1,5 +1,4 @@
 use actix_web::{test, web, App};
-use base64::{engine::general_purpose, Engine as _};
 use serde_json::{json, Value};
 use std::sync::Arc;
 use std::time::Duration;
@@ -55,9 +54,9 @@ async fn test_send_message_basic() {
     )
     .await;
     info!("Testing basic message send");
-    let receiver_id = general_purpose::STANDARD.encode(vec![0x02; 33]);
+    let receiver_id = hex::encode(vec![0x02; 33]);
     let test_message = "Hello, Taproot Assets Mailbox!";
-    let encrypted_payload = general_purpose::STANDARD.encode(test_message.as_bytes());
+    let encrypted_payload = hex::encode(test_message.as_bytes());
     let request = json!({
         "receiver_id": receiver_id,
         "encrypted_payload": encrypted_payload,
@@ -90,7 +89,7 @@ async fn test_receive_messages_flow() {
     )
     .await;
     info!("Testing receive messages flow");
-    let receiver_id = general_purpose::STANDARD.encode(vec![0x02; 33]);
+    let receiver_id = hex::encode(vec![0x02; 33]);
     let init_request = json!({
         "init": {
             "receiver_id": receiver_id,
@@ -114,7 +113,7 @@ async fn test_receive_messages_flow() {
         assert!(challenge["challenge_hash"].is_string());
         let auth_request = json!({
             "auth_sig": {
-                "signature": general_purpose::STANDARD.encode(vec![0u8; 64])
+                "signature": hex::encode(vec![0u8; 64])
             }
         });
         let auth_req = test::TestRequest::post()
@@ -178,8 +177,8 @@ async fn test_mailbox_expiry_handling() {
     .await;
     info!("Testing mailbox message expiry handling");
     let expired_request = json!({
-        "receiver_id": general_purpose::STANDARD.encode(vec![0x02; 33]),
-        "encrypted_payload": general_purpose::STANDARD.encode(b"expired message"),
+        "receiver_id": hex::encode(vec![0x02; 33]),
+        "encrypted_payload": hex::encode(b"expired message"),
         "expiry_block_height": 1
     });
     let req = test::TestRequest::post()
@@ -200,14 +199,16 @@ async fn test_large_message_payload() {
             .app_data(client.clone())
             .app_data(base_url.clone())
             .app_data(macaroon_hex.clone())
+            .app_data(web::JsonConfig::default().limit(10 * 1024 * 1024))
             .configure(configure),
     )
     .await;
     info!("Testing large message payload");
+    // hex doubles the encoded size, so the test app needs production's JSON limit
     let large_payload = vec![0x42u8; 1024 * 1024];
-    let encoded_payload = general_purpose::STANDARD.encode(&large_payload);
+    let encoded_payload = hex::encode(&large_payload);
     let request = json!({
-        "receiver_id": general_purpose::STANDARD.encode(vec![0x02; 33]),
+        "receiver_id": hex::encode(vec![0x02; 33]),
         "encrypted_payload": encoded_payload,
         "expiry_block_height": 200000
     });

--- a/tests/performance.rs
+++ b/tests/performance.rs
@@ -1,5 +1,4 @@
 use actix_web::{test, App};
-use base64::Engine;
 use serde_json::{json, Value};
 use serial_test::serial;
 use std::time::Instant;
@@ -163,7 +162,7 @@ async fn test_large_proof_handling_performance() {
     )
     .await;
 
-    let large_proof = base64::engine::general_purpose::STANDARD.encode(vec![0u8; 1024 * 1024]);
+    let large_proof = hex::encode(vec![0u8; 1024 * 1024]);
     let req = json!({
         "raw_proof": large_proof,
         "proof_at_depth": 0,

--- a/tests/proofs.rs
+++ b/tests/proofs.rs
@@ -1,5 +1,4 @@
 use actix_web::{test, App};
-use base64::{engine::general_purpose, Engine as _};
 use serde_json::{json, Value};
 use serial_test::serial;
 use std::time::Duration;
@@ -7,8 +6,57 @@ use taproot_assets_rest_gateway::api::proofs::{
     DecodeProofRequest, ExportProofRequest, UnpackFileRequest, VerifyProofRequest,
 };
 use taproot_assets_rest_gateway::api::routes::configure;
-use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup};
+use taproot_assets_rest_gateway::tests::setup::{
+    assert_status_matches_body, mint_test_asset, setup, txid_to_internal_hex,
+};
 use tokio::time::sleep;
+
+/// Exports a real proof file for the first asset the daemon holds, returning the
+/// hex-encoded proof and the asset's genesis point.
+async fn export_real_proof(
+    client: &reqwest::Client,
+    base_url: &str,
+    macaroon_hex: &str,
+) -> Option<(String, String)> {
+    let assets: Value = client
+        .get(format!("{base_url}/v1/taproot-assets/assets"))
+        .header("Grpc-Metadata-macaroon", macaroon_hex)
+        .send()
+        .await
+        .ok()?
+        .json()
+        .await
+        .ok()?;
+    let asset = assets["assets"].as_array()?.first()?;
+    let genesis_point = asset["asset_genesis"]["genesis_point"]
+        .as_str()?
+        .to_string();
+    let outpoint = asset["chain_anchor"]["anchor_outpoint"].as_str()?;
+    let (txid, vout) = outpoint.split_once(':')?;
+
+    let body = json!({
+        "asset_id": asset["asset_genesis"]["asset_id"].as_str()?,
+        "script_key": asset["script_key"].as_str()?,
+        "outpoint": {
+            "txid": txid_to_internal_hex(txid),
+            "output_index": vout.parse::<u32>().ok()?
+        }
+    });
+    let exported: Value = client
+        .post(format!("{base_url}/v1/taproot-assets/proofs/export"))
+        .header("Grpc-Metadata-macaroon", macaroon_hex)
+        .json(&body)
+        .send()
+        .await
+        .ok()?
+        .json()
+        .await
+        .ok()?;
+    Some((
+        exported["raw_proof_file"].as_str()?.to_string(),
+        genesis_point,
+    ))
+}
 
 async fn wait_for_asset(
     client: &reqwest::Client,
@@ -74,14 +122,14 @@ async fn test_export_proof() {
         if parts.len() == 2 {
             let txid_hex = parts[0];
             if let Ok(vout) = parts[1].parse::<u32>() {
-                if let Ok(txid_bytes) = hex::decode(txid_hex) {
-                    let txid_base64 = general_purpose::STANDARD.encode(&txid_bytes);
+                if hex::decode(txid_hex).is_ok() {
+                    let txid_hex = txid_to_internal_hex(txid_hex);
                     if let Some(script_key) = asset["script_key"].as_str() {
                         let request = ExportProofRequest {
                             asset_id: asset_id.clone(),
                             script_key: script_key.to_string(),
                             outpoint: json!({
-                                "txid": txid_base64,
+                                "txid": txid_hex,
                                 "output_index": vout
                             }),
                         };
@@ -144,8 +192,12 @@ async fn test_decode_proof() {
     )
     .await;
 
+    let (proof, _) = export_real_proof(&client, &base_url.0, &macaroon_hex.0)
+        .await
+        .expect("daemon should hold a mintable asset with an exportable proof");
+
     let request = json!({
-        "raw_proof": general_purpose::STANDARD.encode("dummy_proof_data"),
+        "raw_proof": proof,
         "proof_at_depth": 0,
         "with_prev_witnesses": true,
         "with_meta_reveal": true
@@ -156,7 +208,14 @@ async fn test_decode_proof() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success() || resp.status().is_client_error());
+    let status = resp.status();
+    let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &json);
+    assert!(
+        status.is_success(),
+        "decoding a real proof must succeed: {json}"
+    );
+    assert!(json["decoded_proof"].is_object());
 }
 
 #[actix_rt::test]
@@ -172,9 +231,13 @@ async fn test_verify_proof() {
     )
     .await;
 
+    let (proof, genesis_point) = export_real_proof(&client, &base_url.0, &macaroon_hex.0)
+        .await
+        .expect("daemon should hold a mintable asset with an exportable proof");
+
     let request = json!({
-        "raw_proof_file": general_purpose::STANDARD.encode("dummy_proof_file_data"),
-        "genesis_point": "0000000000000000000000000000000000000000000000000000000000000000:0"
+        "raw_proof_file": proof,
+        "genesis_point": genesis_point
     });
 
     let req = test::TestRequest::post()
@@ -182,7 +245,14 @@ async fn test_verify_proof() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success() || resp.status().is_client_error());
+    let status = resp.status();
+    let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &json);
+    assert!(
+        status.is_success(),
+        "verifying a real proof must succeed: {json}"
+    );
+    assert_eq!(json["valid"].as_bool(), Some(true));
 }
 
 #[actix_rt::test]
@@ -197,6 +267,10 @@ async fn test_decode_proof_options() {
     )
     .await;
 
+    let (proof, _) = export_real_proof(&client, &base_url.0, &macaroon_hex.0)
+        .await
+        .expect("daemon should hold a mintable asset with an exportable proof");
+
     let test_cases = vec![
         (Some(0), true, true),
         (Some(1), false, false),
@@ -205,7 +279,7 @@ async fn test_decode_proof_options() {
 
     for (depth, with_witnesses, with_meta) in test_cases {
         let request = json!({
-            "raw_proof": general_purpose::STANDARD.encode("dummy_proof_data"),
+            "raw_proof": proof,
             "proof_at_depth": depth,
             "with_prev_witnesses": with_witnesses,
             "with_meta_reveal": with_meta
@@ -216,7 +290,14 @@ async fn test_decode_proof_options() {
             .set_json(&request)
             .to_request();
         let resp = test::call_service(&app, req).await;
-        assert!(resp.status().is_success() || resp.status().is_client_error());
+        let status = resp.status();
+        let json: Value = test::read_body_json(resp).await;
+        assert_status_matches_body(status, &json);
+        assert!(
+            status.is_success(),
+            "decoding a real proof at depth {depth:?} must succeed: {json}"
+        );
+        assert!(json["decoded_proof"].is_object());
     }
 }
 
@@ -234,7 +315,7 @@ async fn test_proof_validation_errors() {
     .await;
 
     let request = json!({
-        "raw_proof": general_purpose::STANDARD.encode(""),
+        "raw_proof": hex::encode(""),
         "proof_at_depth": 0,
         "with_prev_witnesses": true,
         "with_meta_reveal": true
@@ -245,12 +326,10 @@ async fn test_proof_validation_errors() {
         .set_json(&request)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    if resp.status().is_success() {
-        let json: Value = test::read_body_json(resp).await;
-        assert!(json.get("error").is_some() || json.get("code").is_some());
-    } else {
-        assert!(resp.status().is_client_error());
-    }
+    let status = resp.status();
+    let json: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &json);
+    assert!(!status.is_success(), "an empty proof must be rejected");
 }
 
 #[actix_rt::test]
@@ -326,14 +405,14 @@ async fn test_export_asset_proof() {
         if parts.len() == 2 {
             let txid_hex = parts[0];
             if let Ok(vout) = parts[1].parse::<u32>() {
-                if let Ok(txid_bytes) = hex::decode(txid_hex) {
-                    let txid_base64 = general_purpose::STANDARD.encode(&txid_bytes);
+                if hex::decode(txid_hex).is_ok() {
+                    let txid_hex = txid_to_internal_hex(txid_hex);
                     if let Some(script_key) = asset["script_key"].as_str() {
                         let request = ExportProofRequest {
                             asset_id: asset_id.clone(),
                             script_key: script_key.to_string(),
                             outpoint: json!({
-                                "txid": txid_base64,
+                                "txid": txid_hex,
                                 "output_index": vout
                             }),
                         };
@@ -408,14 +487,14 @@ async fn test_unpack_exported_proof_file() {
         if parts.len() == 2 {
             let txid_hex = parts[0];
             if let Ok(vout) = parts[1].parse::<u32>() {
-                if let Ok(txid_bytes) = hex::decode(txid_hex) {
-                    let txid_base64 = general_purpose::STANDARD.encode(&txid_bytes);
+                if hex::decode(txid_hex).is_ok() {
+                    let txid_hex = txid_to_internal_hex(txid_hex);
                     if let Some(script_key) = asset["script_key"].as_str() {
                         let export_req = ExportProofRequest {
                             asset_id: asset_id.clone(),
                             script_key: script_key.to_string(),
                             outpoint: json!({
-                                "txid": txid_base64,
+                                "txid": txid_hex,
                                 "output_index": vout
                             }),
                         };
@@ -506,14 +585,14 @@ async fn test_decode_proof_file() {
         if parts.len() == 2 {
             let txid_hex = parts[0];
             if let Ok(vout) = parts[1].parse::<u32>() {
-                if let Ok(txid_bytes) = hex::decode(txid_hex) {
-                    let txid_base64 = general_purpose::STANDARD.encode(&txid_bytes);
+                if hex::decode(txid_hex).is_ok() {
+                    let txid_hex = txid_to_internal_hex(txid_hex);
                     if let Some(script_key) = asset["script_key"].as_str() {
                         let export_req = ExportProofRequest {
                             asset_id: asset_id.clone(),
                             script_key: script_key.to_string(),
                             outpoint: json!({
-                                "txid": txid_base64,
+                                "txid": txid_hex,
                                 "output_index": vout
                             }),
                         };
@@ -613,14 +692,14 @@ async fn test_verify_proof_validity() {
         if parts.len() == 2 {
             let txid_hex = parts[0];
             if let Ok(vout) = parts[1].parse::<u32>() {
-                if let Ok(txid_bytes) = hex::decode(txid_hex) {
-                    let txid_base64 = general_purpose::STANDARD.encode(&txid_bytes);
+                if hex::decode(txid_hex).is_ok() {
+                    let txid_hex = txid_to_internal_hex(txid_hex);
                     if let Some(script_key) = asset["script_key"].as_str() {
                         let export_req = ExportProofRequest {
                             asset_id: asset_id.clone(),
                             script_key: script_key.to_string(),
                             outpoint: json!({
-                                "txid": txid_base64,
+                                "txid": txid_hex,
                                 "output_index": vout
                             }),
                         };
@@ -713,14 +792,14 @@ async fn test_unpack_proof_file() {
         if parts.len() == 2 {
             let txid_hex = parts[0];
             if let Ok(vout) = parts[1].parse::<u32>() {
-                if let Ok(txid_bytes) = hex::decode(txid_hex) {
-                    let txid_base64 = general_purpose::STANDARD.encode(&txid_bytes);
+                if hex::decode(txid_hex).is_ok() {
+                    let txid_hex = txid_to_internal_hex(txid_hex);
                     if let Some(script_key) = asset["script_key"].as_str() {
                         let export_req = ExportProofRequest {
                             asset_id: asset_id.clone(),
                             script_key: script_key.to_string(),
                             outpoint: json!({
-                                "txid": txid_base64,
+                                "txid": txid_hex,
                                 "output_index": vout
                             }),
                         };
@@ -814,14 +893,14 @@ async fn test_decode_proof_at_different_depths() {
         if parts.len() == 2 {
             let txid_hex = parts[0];
             if let Ok(vout) = parts[1].parse::<u32>() {
-                if let Ok(txid_bytes) = hex::decode(txid_hex) {
-                    let txid_base64 = general_purpose::STANDARD.encode(&txid_bytes);
+                if hex::decode(txid_hex).is_ok() {
+                    let txid_hex = txid_to_internal_hex(txid_hex);
                     if let Some(script_key) = initial_asset["script_key"].as_str() {
                         let export_req = ExportProofRequest {
                             asset_id: asset_id.clone(),
                             script_key: script_key.to_string(),
                             outpoint: json!({
-                                "txid": txid_base64,
+                                "txid": txid_hex,
                                 "output_index": vout
                             }),
                         };

--- a/tests/psbt.rs
+++ b/tests/psbt.rs
@@ -1,5 +1,4 @@
 use actix_web::{test, App};
-use base64::{engine::general_purpose, Engine as _};
 use serde_json::{json, Value};
 use serial_test::serial;
 use taproot_assets_rest_gateway::api::routes::configure;
@@ -8,7 +7,7 @@ use taproot_assets_rest_gateway::api::wallet::{
     VirtualPsbtLogTransferRequest, VirtualPsbtSignRequest,
 };
 use taproot_assets_rest_gateway::tests::setup::{
-    assert_status_matches_body, mint_test_asset, setup,
+    assert_status_matches_body, mint_test_asset, setup, txid_to_internal_hex,
 };
 
 #[actix_rt::test]
@@ -351,7 +350,7 @@ async fn test_commit_virtual_psbt() {
             let commit_request = VirtualPsbtCommitRequest {
                 virtual_psbts: vec![signed_psbt.to_string()],
                 passive_asset_psbts: passive_psbts,
-                anchor_psbt: general_purpose::STANDARD.encode(vec![0u8; 100]), // Dummy anchor PSBT
+                anchor_psbt: hex::encode(vec![0u8; 100]), // Dummy anchor PSBT
                 existing_output_index: -1,
                 add: true,
                 target_conf: 6,
@@ -406,8 +405,8 @@ async fn test_log_psbt_transfer() {
 
     // Test with dummy data since we need properly committed PSBTs
     let request = VirtualPsbtLogTransferRequest {
-        anchor_psbt: general_purpose::STANDARD.encode(vec![0u8; 100]),
-        virtual_psbts: vec![general_purpose::STANDARD.encode(vec![1u8; 100])],
+        anchor_psbt: hex::encode(vec![0u8; 100]),
+        virtual_psbts: vec![hex::encode(vec![1u8; 100])],
         passive_asset_psbts: vec![],
         change_output_index: -1,
         lnd_locked_utxos: vec![],
@@ -567,7 +566,7 @@ async fn test_psbt_with_specific_inputs() {
                             raw: json!({
                                 "inputs": [{
                                     "outpoint": {
-                                        "txid": general_purpose::STANDARD.encode(hex::decode(parts[0]).unwrap_or_default()),
+                                        "txid": txid_to_internal_hex(parts[0]),
                                         "output_index": parts[1].parse::<u32>().unwrap_or(0)
                                     },
                                     "id": asset_id,
@@ -647,14 +646,14 @@ async fn test_commit_psbt_with_custom_parameters() {
 
     // Test with custom lock parameters
     let commit_request = VirtualPsbtCommitRequest {
-        virtual_psbts: vec![general_purpose::STANDARD.encode(vec![1u8; 100])],
+        virtual_psbts: vec![hex::encode(vec![1u8; 100])],
         passive_asset_psbts: vec![],
-        anchor_psbt: general_purpose::STANDARD.encode(vec![0u8; 100]),
+        anchor_psbt: hex::encode(vec![0u8; 100]),
         existing_output_index: -1,
         add: true,
         target_conf: 1,
         sat_per_vbyte: "50".to_string(),
-        custom_lock_id: Some(general_purpose::STANDARD.encode(b"custom_lock_123")),
+        custom_lock_id: Some(hex::encode(b"custom_lock_123")),
         lock_expiration_seconds: Some("300".to_string()),
         skip_funding: true,
     };
@@ -694,9 +693,9 @@ async fn test_anchor_multiple_virtual_psbts() {
     // Test anchoring multiple PSBTs
     let anchor_request = VirtualPsbtAnchorRequest {
         virtual_psbts: vec![
-            general_purpose::STANDARD.encode(vec![1u8; 100]),
-            general_purpose::STANDARD.encode(vec![2u8; 100]),
-            general_purpose::STANDARD.encode(vec![3u8; 100]),
+            hex::encode(vec![1u8; 100]),
+            hex::encode(vec![2u8; 100]),
+            hex::encode(vec![3u8; 100]),
         ],
     };
 
@@ -741,12 +740,12 @@ async fn test_log_transfer_with_label() {
 
     for label in labels {
         let request = VirtualPsbtLogTransferRequest {
-            anchor_psbt: general_purpose::STANDARD.encode(vec![0u8; 100]),
-            virtual_psbts: vec![general_purpose::STANDARD.encode(vec![1u8; 100])],
+            anchor_psbt: hex::encode(vec![0u8; 100]),
+            virtual_psbts: vec![hex::encode(vec![1u8; 100])],
             passive_asset_psbts: vec![],
             change_output_index: 0,
             lnd_locked_utxos: vec![json!({
-                "txid": general_purpose::STANDARD.encode(vec![0u8; 32]),
+                "txid": hex::encode(vec![0u8; 32]),
                 "output_index": 0
             })],
             skip_anchor_tx_broadcast: true,

--- a/tests/transfers.rs
+++ b/tests/transfers.rs
@@ -1,5 +1,4 @@
 use actix_web::{test, App};
-use base64::{engine::general_purpose, Engine as _};
 use serde_json::{json, Value};
 use serial_test::serial;
 use taproot_assets_rest_gateway::api::addresses::NewAddrRequest;
@@ -7,7 +6,9 @@ use taproot_assets_rest_gateway::api::assets::TransferRegisterRequest;
 use taproot_assets_rest_gateway::api::proofs::ExportProofRequest;
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::api::send::SendRequest;
-use taproot_assets_rest_gateway::tests::setup::{mint_test_asset, setup, setup_without_assets};
+use taproot_assets_rest_gateway::tests::setup::{
+    assert_status_matches_body, mint_test_asset, setup, setup_without_assets,
+};
 
 #[actix_rt::test]
 #[serial]
@@ -168,7 +169,7 @@ async fn test_register_transfer() {
             group_key: None,
             script_key: script_key.to_string(),
             outpoint: json!({
-                "txid": general_purpose::STANDARD.encode(vec![0u8; 32]),
+                "txid": hex::encode(vec![0u8; 32]),
                 "output_index": 0
             }),
         };
@@ -178,12 +179,11 @@ async fn test_register_transfer() {
             .set_json(&request)
             .to_request();
         let resp = test::call_service(&app, req).await;
+        let status = resp.status();
+        let register_json: Value = test::read_body_json(resp).await;
+        assert_status_matches_body(status, &register_json);
 
-        // May fail if outpoint doesn't exist, but API structure should be correct
-        assert!(resp.status().is_success() || resp.status().is_client_error());
-
-        if resp.status().is_success() {
-            let register_json: Value = test::read_body_json(resp).await;
+        if status.is_success() {
             assert!(register_json["registered_asset"].is_object());
         }
     }
@@ -241,7 +241,7 @@ async fn test_export_and_verify_transfer_proof() {
             asset_id: asset_id.clone(),
             script_key: script_key.to_string(),
             outpoint: json!({
-                "txid": general_purpose::STANDARD.encode(vec![0u8; 32]),
+                "txid": hex::encode(vec![0u8; 32]),
                 "output_index": 0
             }),
         };

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -1,5 +1,4 @@
 use actix_web::{test, App};
-use base64::Engine;
 use serde_json::{json, Value};
 use serial_test::serial;
 use taproot_assets_rest_gateway::api::routes::configure;
@@ -8,7 +7,7 @@ use taproot_assets_rest_gateway::api::wallet::{
     OwnershipVerifyRequest, ScriptKeyRequest, UtxoLeaseDeleteRequest,
 };
 use taproot_assets_rest_gateway::tests::setup::{
-    assert_status_matches_body, mint_test_asset, setup, setup_without_assets,
+    assert_status_matches_body, mint_test_asset, setup, setup_without_assets, txid_to_internal_hex,
 };
 
 #[actix_rt::test]
@@ -268,17 +267,17 @@ async fn test_prove_asset_ownership() {
 
         if parts.len() == 2 {
             let txid_hex = parts[0];
-            if let Ok(txid_bytes) = hex::decode(txid_hex) {
-                let txid_base64 = base64::engine::general_purpose::STANDARD.encode(&txid_bytes);
+            if hex::decode(txid_hex).is_ok() {
+                let txid_hex = txid_to_internal_hex(txid_hex);
 
                 let request = OwnershipProveRequest {
                     asset_id: asset_id.clone(),
                     script_key: script_key.to_string(),
                     outpoint: json!({
-                        "txid": txid_base64,
+                        "txid": txid_hex,
                         "output_index": parts[1].parse::<u32>().unwrap_or(0)
                     }),
-                    challenge: base64::engine::general_purpose::STANDARD.encode("test_challenge"),
+                    challenge: hex::encode("test_challenge"),
                 };
 
                 let req = test::TestRequest::post()
@@ -348,16 +347,16 @@ async fn test_verify_ownership_proof() {
 
         if parts.len() == 2 {
             let txid_hex = parts[0];
-            if let Ok(txid_bytes) = hex::decode(txid_hex) {
-                let txid_base64 = base64::engine::general_purpose::STANDARD.encode(&txid_bytes);
-                let challenge = base64::engine::general_purpose::STANDARD.encode("test_challenge");
+            if hex::decode(txid_hex).is_ok() {
+                let txid_hex = txid_to_internal_hex(txid_hex);
+                let challenge = hex::encode("test_challenge");
 
                 // First prove ownership
                 let prove_request = OwnershipProveRequest {
                     asset_id: asset_id.clone(),
                     script_key: script_key.to_string(),
                     outpoint: json!({
-                        "txid": txid_base64,
+                        "txid": txid_hex,
                         "output_index": parts[1].parse::<u32>().unwrap_or(0)
                     }),
                     challenge: challenge.clone(),
@@ -424,7 +423,7 @@ async fn test_delete_utxo_lease() {
 
     let request = UtxoLeaseDeleteRequest {
         outpoint: json!({
-            "txid": base64::engine::general_purpose::STANDARD.encode(vec![0u8; 32]),
+            "txid": hex::encode(vec![0u8; 32]),
             "output_index": 0
         }),
     };
@@ -574,17 +573,17 @@ async fn test_ownership_proof_with_invalid_challenge() {
 
         if parts.len() == 2 {
             let txid_hex = parts[0];
-            if let Ok(txid_bytes) = hex::decode(txid_hex) {
-                let txid_base64 = base64::engine::general_purpose::STANDARD.encode(&txid_bytes);
-                let challenge1 = base64::engine::general_purpose::STANDARD.encode("challenge1");
-                let challenge2 = base64::engine::general_purpose::STANDARD.encode("challenge2");
+            if hex::decode(txid_hex).is_ok() {
+                let txid_hex = txid_to_internal_hex(txid_hex);
+                let challenge1 = hex::encode("challenge1");
+                let challenge2 = hex::encode("challenge2");
 
                 // Prove with one challenge
                 let prove_request = OwnershipProveRequest {
                     asset_id: asset_id.clone(),
                     script_key: script_key.to_string(),
                     outpoint: json!({
-                        "txid": txid_base64,
+                        "txid": txid_hex,
                         "output_index": parts[1].parse::<u32>().unwrap_or(0)
                     }),
                     challenge: challenge1,


### PR DESCRIPTION
Fixes #17. Fixes #16.

Verified end to end against a live `tapd 0.8.0` regtest node.

## Body `bytes` fields are hex, not base64

tapd sets the non-standard `UseHexForBytes` on its REST `protojson` options, so protobuf `bytes` in a **JSON body** travel as hex. Sending base64 returns `400 invalid value for bytes type`. This is intentional upstream (lightninglabs/taproot-assets#2077, closed as won't-fix).

44 call sites across 7 test files sent base64. They passed only because the assertions tolerated the resulting error, so a large part of the suite was asserting that malformed requests were correctly rejected rather than that the endpoints work.

Every one of the 44 was checked against the `format: byte` fields in tapd's swagger before conversion. Note the asymmetry, which is now covered by a test: **query** `bytes` parameters are base64 (lightninglabs/taproot-assets#2075, #2080), only body fields are hex.

## txid byte order

`txid` is a `bytes` field, and Bitcoin txids display big-endian but travel little-endian. The tests took the display form from `anchor_outpoint` and encoded it unreversed, so `proofs/export` returned `unable to find proof` even once the encoding was hex. Added `txid_to_internal_hex` and applied it to the 11 sites that derive a txid from a display string.

With that fixed, `proofs/export` returns real proofs, so `test_decode_proof`, `test_decode_proof_options` and `test_verify_proof` now export a proof and assert the success path (`valid: true`, `decoded_proof` present) instead of feeding `"dummy_proof_data"` and accepting any error.

## Gateway bug: `/burns` dropped its query filter

`list_burns` never forwarded the query string, so `GET /burns?asset_id=...` silently returned **every** burn rather than the asset's. A UI filtering burns by asset would show other assets' burns. Fixed by forwarding `req.query_string()`, matching the universe supply handlers.

This was invisible before because `test_list_burns_with_filters` only checked that `burns` was an array and never asserted the filter applied. It now asserts every returned burn matches the requested asset.

## #16: order dependence

`test_list_burns_with_filters` depended on burns left behind by sibling tests. It now discovers an asset that already has a burn and filters on that. It deliberately does **not** create a burn: a burn needs an unlocked, confirmed on-chain UTXO, and the psbt suite leases them, which is what made the ordering matter.

## Other

- `test_large_message_payload` now gives the test app production's 10 MiB `JsonConfig` limit. Hex doubles the encoded size, so a 1 MiB payload exceeded actix's 2 MiB default and was rejected with a non-JSON body.
- `test_proof_validation_errors` now asserts an empty proof is rejected, rather than accepting either outcome.

## Results

Full integration suite against tapd 0.8.0, `stop_daemon` excluded (it shuts the daemon down):

| | passed | failed |
| --- | --- | --- |
| `main` | 179 | 23 |
| this branch | **184** | **18** |

Five tests fixed, no new failures. The 18 remaining failures all reproduce on `main` and are unrelated to byte encoding; they are tracked separately.

Unit tests remain 92/92. `cargo fmt --check` and `clippy --all-targets -D warnings` pass.
