### PR TITLE
bump version to v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "taproot-assets-rest-gateway"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taproot-assets-rest-gateway"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "REST API proxy for Lightning Labs' Taproot Assets"
 readme = "README.md"


### PR DESCRIPTION
Patch release for the `/burns` query-filter fix merged in #18.

`GET /v1/taproot-assets/burns?asset_id=...` previously returned **every** burn, because `list_burns` never forwarded the query string to tapd. A client filtering burns by asset received other assets' burns. Verified against a live tapd 0.8.0 node: 39 burns unfiltered, 8 when filtered, all matching the requested asset.

This is the only user-facing change since v0.3.0; everything else in the range is test-side.

Note for library consumers: `api::burn::list_burns` gained a `query: &str` parameter. The crate is not published to crates.io and ships as a binary, so this is released as a patch.