### PR TITLE
Forward query parameters to tapd in all GET handlers

### DIFF
--- a/src/api/assets.rs
+++ b/src/api/assets.rs
@@ -1,7 +1,7 @@
-use super::{handle_result, parse_upstream};
+use super::{handle_result, parse_upstream, with_query};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
-use actix_web::{web, HttpResponse};
+use actix_web::{web, HttpRequest, HttpResponse};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tracing::{info, instrument};
@@ -152,9 +152,10 @@ pub async fn list_assets(
     client: &Client,
     base_url: &str,
     macaroon_hex: &str,
+    query: &str,
 ) -> Result<Vec<Asset>, AppError> {
     info!("Listing assets");
-    let url = format!("{base_url}/v1/taproot-assets/assets");
+    let url = with_query(format!("{base_url}/v1/taproot-assets/assets"), query);
     let response = client
         .get(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
@@ -191,9 +192,13 @@ pub async fn get_balance(
     client: &Client,
     base_url: &str,
     macaroon_hex: &str,
+    query: &str,
 ) -> Result<serde_json::Value, AppError> {
     info!("Fetching asset balance");
-    let url = format!("{base_url}/v1/taproot-assets/assets/balance");
+    let url = with_query(
+        format!("{base_url}/v1/taproot-assets/assets/balance"),
+        query,
+    );
     let response = client
         .get(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
@@ -226,9 +231,13 @@ pub async fn get_meta(
     base_url: &str,
     macaroon_hex: &str,
     asset_id: &str,
+    query: &str,
 ) -> Result<serde_json::Value, AppError> {
     info!("Fetching meta for asset ID: {}", asset_id);
-    let url = format!("{base_url}/v1/taproot-assets/assets/meta/asset-id/{asset_id}");
+    let url = with_query(
+        format!("{base_url}/v1/taproot-assets/assets/meta/asset-id/{asset_id}"),
+        query,
+    );
     let response = client
         .get(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
@@ -244,9 +253,13 @@ pub async fn get_mint_batches(
     base_url: &str,
     macaroon_hex: &str,
     batch_key: &str,
+    query: &str,
 ) -> Result<serde_json::Value, AppError> {
     info!("Fetching mint batches for batch key: {}", batch_key);
-    let url = format!("{base_url}/v1/taproot-assets/assets/mint/batches/{batch_key}");
+    let url = with_query(
+        format!("{base_url}/v1/taproot-assets/assets/mint/batches/{batch_key}"),
+        query,
+    );
     let response = client
         .get(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
@@ -359,9 +372,13 @@ pub async fn get_transfers(
     client: &Client,
     base_url: &str,
     macaroon_hex: &str,
+    query: &str,
 ) -> Result<serde_json::Value, AppError> {
     info!("Fetching asset transfers");
-    let url = format!("{base_url}/v1/taproot-assets/assets/transfers");
+    let url = with_query(
+        format!("{base_url}/v1/taproot-assets/assets/transfers"),
+        query,
+    );
     let response = client
         .get(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
@@ -395,9 +412,10 @@ pub async fn get_utxos(
     client: &Client,
     base_url: &str,
     macaroon_hex: &str,
+    query: &str,
 ) -> Result<serde_json::Value, AppError> {
     info!("Fetching asset UTXOs");
-    let url = format!("{base_url}/v1/taproot-assets/assets/utxos");
+    let url = with_query(format!("{base_url}/v1/taproot-assets/assets/utxos"), query);
     let response = client
         .get(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
@@ -408,6 +426,7 @@ pub async fn get_utxos(
 }
 
 async fn list_handler(
+    http_req: HttpRequest,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
     macaroon_hex: web::Data<MacaroonHex>,
@@ -416,6 +435,7 @@ async fn list_handler(
         client.as_ref(),
         base_url.0.as_str(),
         macaroon_hex.0.as_str(),
+        http_req.query_string(),
     )
     .await
     {
@@ -454,6 +474,7 @@ async fn mint_handler(
 }
 
 async fn balance_handler(
+    http_req: HttpRequest,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
     macaroon_hex: web::Data<MacaroonHex>,
@@ -463,6 +484,7 @@ async fn balance_handler(
             client.as_ref(),
             base_url.0.as_str(),
             macaroon_hex.0.as_str(),
+            http_req.query_string(),
         )
         .await,
     )
@@ -484,6 +506,7 @@ async fn groups_handler(
 }
 
 async fn meta_handler(
+    http_req: HttpRequest,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
     macaroon_hex: web::Data<MacaroonHex>,
@@ -496,12 +519,14 @@ async fn meta_handler(
             base_url.0.as_str(),
             macaroon_hex.0.as_str(),
             asset_id.as_str(),
+            http_req.query_string(),
         )
         .await,
     )
 }
 
 async fn mint_batches_handler(
+    http_req: HttpRequest,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
     macaroon_hex: web::Data<MacaroonHex>,
@@ -514,6 +539,7 @@ async fn mint_batches_handler(
             base_url.0.as_str(),
             macaroon_hex.0.as_str(),
             batch_key.as_str(),
+            http_req.query_string(),
         )
         .await,
     )
@@ -601,6 +627,7 @@ async fn seal_mint_handler(
 }
 
 async fn transfers_handler(
+    http_req: HttpRequest,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
     macaroon_hex: web::Data<MacaroonHex>,
@@ -610,6 +637,7 @@ async fn transfers_handler(
             client.as_ref(),
             base_url.0.as_str(),
             macaroon_hex.0.as_str(),
+            http_req.query_string(),
         )
         .await,
     )
@@ -633,6 +661,7 @@ async fn register_transfer_handler(
 }
 
 async fn utxos_handler(
+    http_req: HttpRequest,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
     macaroon_hex: web::Data<MacaroonHex>,
@@ -642,6 +671,7 @@ async fn utxos_handler(
             client.as_ref(),
             base_url.0.as_str(),
             macaroon_hex.0.as_str(),
+            http_req.query_string(),
         )
         .await,
     )

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -92,6 +92,17 @@ pub fn validate_integer_param(value: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Appends the caller's query string to an upstream URL. tapd exposes filters,
+/// pagination and required parameters such as `group_by` this way, so dropping
+/// the query silently returns unfiltered results.
+pub fn with_query(mut url: String, query: &str) -> String {
+    if !query.is_empty() {
+        url.push('?');
+        url.push_str(query);
+    }
+    url
+}
+
 /// Deserializes a tapd response, surfacing non-2xx statuses as errors instead
 /// of relaying the upstream error body with a 200.
 pub async fn parse_upstream<T: serde::de::DeserializeOwned>(
@@ -158,6 +169,16 @@ mod tests {
     fn test_validate_group_key_rejects_traversal() {
         assert!(validate_group_key("../../etc/passwd").is_err());
         assert!(validate_group_key("%2e%2e%2fadmin").is_err());
+    }
+
+    #[test]
+    fn test_with_query_appends_and_preserves() {
+        let base = "https://host/v1/taproot-assets/burns".to_string();
+        assert_eq!(with_query(base.clone(), ""), base);
+        assert_eq!(
+            with_query(base.clone(), "asset_id=abc&limit=2"),
+            "https://host/v1/taproot-assets/burns?asset_id=abc&limit=2"
+        );
     }
 
     async fn body_of(resp: HttpResponse) -> serde_json::Value {

--- a/src/api/universe.rs
+++ b/src/api/universe.rs
@@ -1,5 +1,6 @@
 use super::{
     handle_result, parse_upstream, validate_group_key, validate_hex_param, validate_integer_param,
+    with_query,
 };
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
@@ -161,9 +162,13 @@ pub async fn get_keys(
     base_url: &str,
     macaroon_hex: &str,
     asset_id: &str,
+    query: &str,
 ) -> Result<Value, AppError> {
     info!("Fetching keys for asset ID: {}", asset_id);
-    let url = format!("{base_url}/v1/taproot-assets/universe/keys/asset-id/{asset_id}");
+    let url = with_query(
+        format!("{base_url}/v1/taproot-assets/universe/keys/asset-id/{asset_id}"),
+        query,
+    );
     let response = client
         .get(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
@@ -179,9 +184,13 @@ pub async fn get_leaves(
     base_url: &str,
     macaroon_hex: &str,
     asset_id: &str,
+    query: &str,
 ) -> Result<Value, AppError> {
     info!("Fetching leaves for asset ID: {}", asset_id);
-    let url = format!("{base_url}/v1/taproot-assets/universe/leaves/asset-id/{asset_id}");
+    let url = with_query(
+        format!("{base_url}/v1/taproot-assets/universe/leaves/asset-id/{asset_id}"),
+        query,
+    );
     let response = client
         .get(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
@@ -210,6 +219,7 @@ pub async fn get_multiverse(
     parse_upstream::<Value>(response).await
 }
 
+#[allow(clippy::too_many_arguments)]
 #[instrument(skip(client, macaroon_hex))]
 pub async fn get_proofs(
     client: &Client,
@@ -219,10 +229,14 @@ pub async fn get_proofs(
     hash_str: &str,
     index: &str,
     script_key: &str,
+    query: &str,
 ) -> Result<Value, AppError> {
     info!("Fetching proofs for asset ID: {}", asset_id);
-    let url = format!(
-        "{base_url}/v1/taproot-assets/universe/proofs/asset-id/{asset_id}/{hash_str}/{index}/{script_key}"
+    let url = with_query(
+        format!(
+            "{base_url}/v1/taproot-assets/universe/proofs/asset-id/{asset_id}/{hash_str}/{index}/{script_key}"
+        ),
+        query,
     );
     let response = client
         .get(&url)
@@ -264,9 +278,13 @@ pub async fn get_roots(
     client: &Client,
     base_url: &str,
     macaroon_hex: &str,
+    query: &str,
 ) -> Result<Value, AppError> {
     info!("Fetching universe roots");
-    let url = format!("{base_url}/v1/taproot-assets/universe/roots");
+    let url = with_query(
+        format!("{base_url}/v1/taproot-assets/universe/roots"),
+        query,
+    );
     let response = client
         .get(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
@@ -282,9 +300,13 @@ pub async fn get_asset_roots(
     base_url: &str,
     macaroon_hex: &str,
     asset_id: &str,
+    query: &str,
 ) -> Result<Value, AppError> {
     info!("Fetching asset roots for asset ID: {}", asset_id);
-    let url = format!("{base_url}/v1/taproot-assets/universe/roots/asset-id/{asset_id}");
+    let url = with_query(
+        format!("{base_url}/v1/taproot-assets/universe/roots/asset-id/{asset_id}"),
+        query,
+    );
     let response = client
         .get(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
@@ -316,9 +338,13 @@ pub async fn get_asset_stats(
     client: &Client,
     base_url: &str,
     macaroon_hex: &str,
+    query: &str,
 ) -> Result<Value, AppError> {
     info!("Fetching asset stats");
-    let url = format!("{base_url}/v1/taproot-assets/universe/stats/assets");
+    let url = with_query(
+        format!("{base_url}/v1/taproot-assets/universe/stats/assets"),
+        query,
+    );
     let response = client
         .get(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
@@ -333,9 +359,13 @@ pub async fn get_event_stats(
     client: &Client,
     base_url: &str,
     macaroon_hex: &str,
+    query: &str,
 ) -> Result<Value, AppError> {
     info!("Fetching event stats");
-    let url = format!("{base_url}/v1/taproot-assets/universe/stats/events");
+    let url = with_query(
+        format!("{base_url}/v1/taproot-assets/universe/stats/events"),
+        query,
+    );
     let response = client
         .get(&url)
         .header("Grpc-Metadata-macaroon", macaroon_hex)
@@ -564,6 +594,7 @@ async fn info_handler(
 }
 
 async fn keys_handler(
+    http_req: HttpRequest,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
     macaroon_hex: web::Data<MacaroonHex>,
@@ -573,10 +604,20 @@ async fn keys_handler(
     if let Err(e) = validate_hex_param(&asset_id) {
         return handle_result::<serde_json::Value>(Err(e));
     }
-    handle_result(get_keys(client.as_ref(), &base_url.0, &macaroon_hex.0, &asset_id).await)
+    handle_result(
+        get_keys(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            &asset_id,
+            http_req.query_string(),
+        )
+        .await,
+    )
 }
 
 async fn leaves_handler(
+    http_req: HttpRequest,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
     macaroon_hex: web::Data<MacaroonHex>,
@@ -586,7 +627,16 @@ async fn leaves_handler(
     if let Err(e) = validate_hex_param(&asset_id) {
         return handle_result::<serde_json::Value>(Err(e));
     }
-    handle_result(get_leaves(client.as_ref(), &base_url.0, &macaroon_hex.0, &asset_id).await)
+    handle_result(
+        get_leaves(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            &asset_id,
+            http_req.query_string(),
+        )
+        .await,
+    )
 }
 
 async fn fetch_supply_commit_handler(
@@ -716,6 +766,7 @@ async fn multiverse_handler(
 }
 
 async fn proofs_handler(
+    http_req: HttpRequest,
     path: web::Path<(String, String, String, String)>,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
@@ -738,6 +789,7 @@ async fn proofs_handler(
             &hash_str,
             &index,
             &script_key,
+            http_req.query_string(),
         )
         .await,
     )
@@ -774,14 +826,24 @@ async fn push_proof_handler(
 }
 
 async fn roots_handler(
+    http_req: HttpRequest,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
     macaroon_hex: web::Data<MacaroonHex>,
 ) -> HttpResponse {
-    handle_result(get_roots(client.as_ref(), &base_url.0, &macaroon_hex.0).await)
+    handle_result(
+        get_roots(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            http_req.query_string(),
+        )
+        .await,
+    )
 }
 
 async fn asset_roots_handler(
+    http_req: HttpRequest,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
     macaroon_hex: web::Data<MacaroonHex>,
@@ -791,7 +853,16 @@ async fn asset_roots_handler(
     if let Err(e) = validate_hex_param(&asset_id) {
         return handle_result::<serde_json::Value>(Err(e));
     }
-    handle_result(get_asset_roots(client.as_ref(), &base_url.0, &macaroon_hex.0, &asset_id).await)
+    handle_result(
+        get_asset_roots(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            &asset_id,
+            http_req.query_string(),
+        )
+        .await,
+    )
 }
 
 async fn stats_handler(
@@ -803,19 +874,37 @@ async fn stats_handler(
 }
 
 async fn asset_stats_handler(
+    http_req: HttpRequest,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
     macaroon_hex: web::Data<MacaroonHex>,
 ) -> HttpResponse {
-    handle_result(get_asset_stats(client.as_ref(), &base_url.0, &macaroon_hex.0).await)
+    handle_result(
+        get_asset_stats(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            http_req.query_string(),
+        )
+        .await,
+    )
 }
 
 async fn event_stats_handler(
+    http_req: HttpRequest,
     client: web::Data<Client>,
     base_url: web::Data<BaseUrl>,
     macaroon_hex: web::Data<MacaroonHex>,
 ) -> HttpResponse {
-    handle_result(get_event_stats(client.as_ref(), &base_url.0, &macaroon_hex.0).await)
+    handle_result(
+        get_event_stats(
+            client.as_ref(),
+            &base_url.0,
+            &macaroon_hex.0,
+            http_req.query_string(),
+        )
+        .await,
+    )
 }
 
 async fn sync_handler(

--- a/tests/asset_listing_balance.rs
+++ b/tests/asset_listing_balance.rs
@@ -72,7 +72,7 @@ async fn test_get_asset_balance() {
     .await;
 
     let req = test::TestRequest::get()
-        .uri("/v1/taproot-assets/assets/balance")
+        .uri("/v1/taproot-assets/assets/balance?asset_id=true")
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert!(resp.status().is_success());
@@ -355,14 +355,14 @@ async fn test_asset_balance_with_filters() {
 
     // Test with include_leased
     let leased_req = test::TestRequest::get()
-        .uri("/v1/taproot-assets/assets/balance?include_leased=true")
+        .uri("/v1/taproot-assets/assets/balance?asset_id=true&include_leased=true")
         .to_request();
     let leased_resp = test::call_service(&app, leased_req).await;
     assert!(leased_resp.status().is_success());
 
     // Test with script_key_type filter
     let script_type_req = test::TestRequest::get()
-        .uri("/v1/taproot-assets/assets/balance?script_key_type.explicit_type=SCRIPT_KEY_BIP86")
+        .uri("/v1/taproot-assets/assets/balance?asset_id=true&script_key_type.explicit_type=SCRIPT_KEY_BIP86")
         .to_request();
     let script_type_resp = test::call_service(&app, script_type_req).await;
     assert!(script_type_resp.status().is_success());

--- a/tests/assets.rs
+++ b/tests/assets.rs
@@ -92,7 +92,7 @@ async fn test_get_balance() {
     )
     .await;
     let req = test::TestRequest::get()
-        .uri("/v1/taproot-assets/assets/balance")
+        .uri("/v1/taproot-assets/assets/balance?asset_id=true")
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert!(resp.status().is_success());

--- a/tests/benchmarks.rs
+++ b/tests/benchmarks.rs
@@ -24,7 +24,10 @@ async fn test_throughput_benchmark() {
     let endpoints = vec![
         ("/v1/taproot-assets/getinfo", "GetInfo"),
         ("/v1/taproot-assets/assets", "ListAssets"),
-        ("/v1/taproot-assets/assets/balance", "GetBalance"),
+        (
+            "/v1/taproot-assets/assets/balance?asset_id=true",
+            "GetBalance",
+        ),
         ("/health", "Health Check"),
     ];
 
@@ -275,7 +278,10 @@ async fn test_api_response_time_percentiles() {
     let endpoints = vec![
         ("/v1/taproot-assets/getinfo", "GetInfo"),
         ("/v1/taproot-assets/assets", "ListAssets"),
-        ("/v1/taproot-assets/assets/balance", "GetBalance"),
+        (
+            "/v1/taproot-assets/assets/balance?asset_id=true",
+            "GetBalance",
+        ),
         ("/v1/taproot-assets/addrs", "ListAddresses"),
     ];
 

--- a/tests/integration_scenarios.rs
+++ b/tests/integration_scenarios.rs
@@ -81,7 +81,7 @@ async fn test_complete_asset_lifecycle() {
     let balance_resp = test::call_service(
         &app,
         test::TestRequest::get()
-            .uri("/v1/taproot-assets/assets/balance")
+            .uri("/v1/taproot-assets/assets/balance?asset_id=true")
             .to_request(),
     )
     .await;

--- a/tests/performance.rs
+++ b/tests/performance.rs
@@ -90,7 +90,7 @@ async fn test_concurrent_transfer_performance() {
     let _ = test::call_service(
         &app,
         test::TestRequest::get()
-            .uri("/v1/taproot-assets/assets/balance")
+            .uri("/v1/taproot-assets/assets/balance?asset_id=true")
             .to_request(),
     )
     .await;
@@ -206,7 +206,7 @@ async fn test_high_frequency_balance_queries() {
         let _ = test::call_service(
             &app,
             test::TestRequest::get()
-                .uri("/v1/taproot-assets/assets/balance")
+                .uri("/v1/taproot-assets/assets/balance?asset_id=true")
                 .to_request(),
         )
         .await;
@@ -217,7 +217,7 @@ async fn test_high_frequency_balance_queries() {
 
     for _ in 0..num_queries {
         let req = test::TestRequest::get()
-            .uri("/v1/taproot-assets/assets/balance")
+            .uri("/v1/taproot-assets/assets/balance?asset_id=true")
             .to_request();
         let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
@@ -403,7 +403,7 @@ async fn test_api_response_time_percentiles() {
     let endpoints = vec![
         "/v1/taproot-assets/getinfo",
         "/v1/taproot-assets/assets",
-        "/v1/taproot-assets/assets/balance",
+        "/v1/taproot-assets/assets/balance?asset_id=true",
         "/v1/taproot-assets/addrs",
     ];
 

--- a/tests/transfers.rs
+++ b/tests/transfers.rs
@@ -7,7 +7,7 @@ use taproot_assets_rest_gateway::api::proofs::ExportProofRequest;
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::api::send::SendRequest;
 use taproot_assets_rest_gateway::tests::setup::{
-    assert_status_matches_body, mint_test_asset, setup, setup_without_assets,
+    assert_status_matches_body, mint_test_asset, setup, setup_without_assets, txid_to_internal_hex,
 };
 
 #[actix_rt::test]
@@ -468,5 +468,83 @@ async fn test_transfer_timestamps_and_fees() {
                 assert!(transfer["anchor_tx_block_hash"].is_object());
             }
         }
+    }
+}
+
+/// Regression test: the gateway used to drop query strings, so filtered
+/// requests silently returned the unfiltered result set.
+///
+/// Note the upstream inconsistency: `/burns` takes `asset_id` as base64, while
+/// `/assets/transfers` takes `anchor_txid` as hex in internal (reversed) order.
+#[actix_rt::test]
+#[serial]
+async fn test_transfers_filter_is_forwarded() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/v1/taproot-assets/assets/transfers")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    let all: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &all);
+    assert!(status.is_success());
+
+    let Some(transfers) = all["transfers"].as_array().filter(|t| !t.is_empty()) else {
+        return;
+    };
+    let total = transfers.len();
+    let anchor = transfers[0]["anchor_tx_hash"]
+        .as_str()
+        .expect("anchor_tx_hash")
+        .to_string();
+
+    // No transfer is anchored to an all-zero txid, so a forwarded filter
+    // returns nothing. If the query were dropped we would get all of them.
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/v1/taproot-assets/assets/transfers?anchor_txid={}",
+            "0".repeat(64)
+        ))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    let none: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &none);
+    assert!(status.is_success());
+    let matched = none["transfers"].as_array().map(|t| t.len()).unwrap_or(0);
+    assert_eq!(
+        matched, 0,
+        "filter was dropped: got {matched} transfers, unfiltered total is {total}"
+    );
+
+    // Filtering by a real anchor txid returns only that transfer.
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/v1/taproot-assets/assets/transfers?anchor_txid={}",
+            txid_to_internal_hex(&anchor)
+        ))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    let filtered: Value = test::read_body_json(resp).await;
+    assert_status_matches_body(status, &filtered);
+    assert!(status.is_success());
+
+    let matched = filtered["transfers"].as_array().expect("transfers");
+    assert!(
+        !matched.is_empty(),
+        "the anchoring transfer must be returned"
+    );
+    for t in matched {
+        assert_eq!(t["anchor_tx_hash"].as_str(), Some(anchor.as_str()));
     }
 }

--- a/tests/ui_specific.rs
+++ b/tests/ui_specific.rs
@@ -79,7 +79,7 @@ async fn test_real_time_balance_updates() {
 
     let get_balance = || async {
         let req = test::TestRequest::get()
-            .uri("/v1/taproot-assets/assets/balance")
+            .uri("/v1/taproot-assets/assets/balance?asset_id=true")
             .to_request();
         let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
@@ -382,7 +382,7 @@ async fn test_refresh_data_functionality() {
 
     let endpoints = vec![
         "/v1/taproot-assets/assets",
-        "/v1/taproot-assets/assets/balance",
+        "/v1/taproot-assets/assets/balance?asset_id=true",
         "/v1/taproot-assets/assets/transfers",
         "/v1/taproot-assets/addrs",
     ];


### PR DESCRIPTION
Every `GET` handler except `/burns` and the universe supply endpoints dropped the caller's query string before calling tapd. tapd exposes filters, pagination, and *required* parameters that way, so filtered requests silently returned the unfiltered result set with a `200 OK`.

`/burns` was fixed in v0.3.1. It was not a one-off; it was one instance of a systemic defect. 24 GET handlers dropped the query, 13 of which proxy tapd endpoints that accept query parameters.

Verified end to end against a live `tapd 0.8.0` regtest node.

## Two user-facing bugs

**`GET /assets/balance` never worked.** tapd requires a `group_by` (`?asset_id=true` or `?group_key=true`). The gateway dropped it, so tapd answered `500 invalid group_by`. Before v0.3.0 that error was relayed as a `200`, which is why nobody noticed.

**`GET /assets/transfers?anchor_txid=…` returned the wrong data.** Filtering returned all 46 transfers instead of the matching one. Same silent-wrong-answer shape as the `/burns` bug.

The rest silently ignored filters and pagination: `/assets`, `/assets/utxos`, `/assets/meta/...`, `/assets/mint/batches/{batch_key}`, `/universe/roots`, `/universe/roots/asset-id/...`, `/universe/keys/...`, `/universe/leaves/...`, `/universe/proofs/...`, `/universe/stats/assets`, `/universe/stats/events`.

## Change

Adds `with_query()` in `src/api/mod.rs` and threads the caller's `req.query_string()` through the 13 handlers whose upstream endpoint takes query parameters. `get_groups`, `list_all_mint_batches`, `get_stats` and the rest are untouched: their tapd endpoints define no query parameters.

Each handler was checked against the `in: query` parameters in tapd's swagger rather than changed wholesale.

## Tests

- `with_query` unit test (runs in CI).
- `test_transfers_filter_is_forwarded` asserts a filter both narrows to the matching transfer and returns nothing for an unmatched txid. Mutation-tested: reverting the fix produces `filter was dropped: got 46 transfers, unfiltered total is 46`.
- Balance tests now send a `group_by`, because a bare `/assets/balance` is an invalid request to tapd. The gateway passes that through rather than inventing a default.

Two encoding quirks are now documented in the tests, since they cost real debugging time: `/burns` takes `asset_id` as **base64**, while `/assets/transfers` takes `anchor_txid` as **hex in internal (reversed) byte order**.

## Results

Full integration suite against tapd 0.8.0, `stop_daemon` excluded:

| | passed | failed |
| --- | --- | --- |
| before (v0.3.1) | 184 | 18 |
| this branch | **192** | **11** |

Seven more tests fixed, none newly broken. Unit tests 92 → 93. `fmt` and `clippy --all-targets -D warnings` pass.

Remaining failures are tracked in #19 and are unrelated to query forwarding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for forwarding query parameters across asset and universe API endpoints.
  * Filters and other query options now reach the upstream service, improving filtering and response customization.

* **Bug Fixes**
  * Fixed transfer filtering so anchor transaction queries return the expected results.

* **Tests**
  * Added regression coverage for forwarded transfer filters and updated balance endpoint scenarios to include query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->