### PR TITLE
bump version to v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "taproot-assets-rest-gateway"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taproot-assets-rest-gateway"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "REST API proxy for Lightning Labs' Taproot Assets"
 readme = "README.md"


### PR DESCRIPTION
Patch release for the query-parameter forwarding fix merged in #21.

Every GET handler except `/burns` and the universe supply endpoints dropped the caller's query string, so filters and pagination were silently ignored. `GET /assets/balance` returned `500 invalid group_by` because tapd's required `group_by` parameter never reached it, and `GET /assets/transfers?anchor_txid=...` returned every transfer instead of the matching one.

Verified against a live tapd 0.8.0 node. No API surface changes beyond parameters now taking effect.