### PR TITLE
Surface upstream errors from send, list_assets and list_addresses

### DIFF
--- a/src/api/addresses.rs
+++ b/src/api/addresses.rs
@@ -150,10 +150,7 @@ pub async fn list_addresses(
         .await
         .map_err(AppError::RequestError)?;
 
-    let json = response
-        .json::<HashMap<String, Vec<Addr>>>()
-        .await
-        .map_err(AppError::RequestError)?;
+    let json = parse_upstream::<HashMap<String, Vec<Addr>>>(response).await?;
 
     let mut addresses = json.get("addrs").cloned().unwrap_or_default();
 

--- a/src/api/assets.rs
+++ b/src/api/assets.rs
@@ -163,7 +163,7 @@ pub async fn list_assets(
         .await
         .map_err(AppError::RequestError)?;
 
-    let asset_response: AssetResponse = response.json().await.map_err(AppError::RequestError)?;
+    let asset_response: AssetResponse = parse_upstream(response).await?;
 
     Ok(asset_response.into_assets())
 }

--- a/src/api/send.rs
+++ b/src/api/send.rs
@@ -1,4 +1,4 @@
-use super::handle_result;
+use super::{handle_result, parse_upstream};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpResponse};
@@ -33,7 +33,7 @@ pub async fn send_assets(
         .send()
         .await
         .map_err(AppError::RequestError)?;
-    response.json().await.map_err(AppError::RequestError)
+    parse_upstream::<serde_json::Value>(response).await
 }
 
 async fn send_handler(

--- a/tests/send.rs
+++ b/tests/send.rs
@@ -1,11 +1,11 @@
 use actix_web::{test, App};
-use serde_json::Value;
+use serde_json::{json, Value};
 use serial_test::serial;
 use taproot_assets_rest_gateway::api::addresses::NewAddrRequest;
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::api::send::SendRequest;
 use taproot_assets_rest_gateway::tests::setup::{
-    assert_status_matches_body, mint_test_asset, setup,
+    assert_status_matches_body, mint_test_asset, setup, setup_without_assets,
 };
 
 #[actix_rt::test]
@@ -318,7 +318,7 @@ async fn test_send_validation_errors() {
             .configure(configure),
     )
     .await;
-    // Test with empty addresses
+    // A send with no addresses must be rejected, not reported as success.
     let empty_request = SendRequest {
         tap_addrs: vec![],
         fee_rate: Some(300),
@@ -330,15 +330,15 @@ async fn test_send_validation_errors() {
         .set_json(&empty_request)
         .to_request();
     let empty_resp = test::call_service(&app, empty_req).await;
-    let empty_resp_status = empty_resp.status();
+    let empty_status = empty_resp.status();
     let empty_json: Value = test::read_body_json(empty_resp).await;
-    assert_status_matches_body(empty_resp_status, &empty_json);
-    if empty_json.get("error").is_some() || empty_json.get("code").is_some() {
-        println!("Empty address error: {empty_json:?}");
-    } else {
-        panic!("Expected error for empty addresses");
-    }
-    // Test with invalid address
+    assert_status_matches_body(empty_status, &empty_json);
+    assert!(
+        !empty_status.is_success(),
+        "empty addresses must be rejected"
+    );
+
+    // Likewise for a malformed address.
     let invalid_request = SendRequest {
         tap_addrs: vec!["invalid_address".to_string()],
         fee_rate: Some(300),
@@ -350,11 +350,13 @@ async fn test_send_validation_errors() {
         .set_json(&invalid_request)
         .to_request();
     let invalid_resp = test::call_service(&app, invalid_req).await;
-    assert!(invalid_resp.status().is_success() || invalid_resp.status().is_client_error());
-    if invalid_resp.status().is_success() {
-        let invalid_json: Value = test::read_body_json(invalid_resp).await;
-        assert!(invalid_json.get("error").is_some() || invalid_json.get("code").is_some());
-    }
+    let invalid_status = invalid_resp.status();
+    let invalid_json: Value = test::read_body_json(invalid_resp).await;
+    assert_status_matches_body(invalid_status, &invalid_json);
+    assert!(
+        !invalid_status.is_success(),
+        "a malformed address must be rejected"
+    );
 }
 
 #[actix_rt::test]
@@ -453,4 +455,36 @@ async fn test_send_response_structure() {
             assert!(valid_statuses.contains(&status));
         }
     }
+}
+
+/// Regression test: `send_assets` relayed tapd's response verbatim, so a failed
+/// send arrived as `200 OK` with an error body and callers could not tell it
+/// apart from success.
+#[actix_rt::test]
+#[serial]
+async fn test_failed_send_does_not_report_success() {
+    let (client, base_url, macaroon_hex) = setup_without_assets().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/v1/taproot-assets/send")
+        .set_json(json!({ "tap_addrs": [] }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    let json: Value = test::read_body_json(resp).await;
+
+    assert_status_matches_body(status, &json);
+    assert!(
+        !status.is_success(),
+        "a send with no addresses must not report success: {status} {json}"
+    );
+    assert_eq!(json["code"].as_i64(), Some(2));
 }

--- a/tests/transfers.rs
+++ b/tests/transfers.rs
@@ -7,8 +7,10 @@ use taproot_assets_rest_gateway::api::proofs::ExportProofRequest;
 use taproot_assets_rest_gateway::api::routes::configure;
 use taproot_assets_rest_gateway::api::send::SendRequest;
 use taproot_assets_rest_gateway::tests::setup::{
-    assert_status_matches_body, mint_test_asset, setup, setup_without_assets, txid_to_internal_hex,
+    assert_status_matches_body, generate_blocks_with_retry, mint_test_asset, setup,
+    setup_without_assets, txid_to_internal_hex,
 };
+use tokio::time::{sleep, Duration};
 
 #[actix_rt::test]
 #[serial]
@@ -59,16 +61,53 @@ async fn test_complete_transfer_workflow() {
         label: Some("Transfer test".to_string()),
         skip_proof_courier_ping_check: Some(true),
     };
-    let send_resp = test::call_service(
+    let send_body = serde_json::to_value(&send_req).expect("serialize send request");
+
+    let resp = test::call_service(
         &app,
         test::TestRequest::post()
             .uri("/v1/taproot-assets/send")
-            .set_json(&send_req)
+            .set_json(&send_body)
             .to_request(),
     )
     .await;
-    assert!(send_resp.status().is_success());
-    let _send_json: Value = test::read_body_json(send_resp).await;
+    let mut send_status = resp.status();
+    let mut send_json: Value = test::read_body_json(resp).await;
+
+    // A send needs confirmed on-chain coins to anchor with. Sibling tests leave
+    // change unconfirmed, so mine and retry once on a funding failure rather
+    // than mining unconditionally, which would perturb their UTXO state.
+    let funding_failure = |body: &Value| {
+        let msg = body["message"].as_str().unwrap_or_default();
+        msg.contains("un-confirmed")
+            || msg.contains("not enough witness outputs")
+            || msg.contains("insufficient")
+    };
+    if !send_status.is_success() && funding_failure(&send_json) {
+        let rpc_url = std::env::var("BITCOIN_RPC_URL").unwrap_or_default();
+        let rpc_user = std::env::var("BITCOIN_RPC_USER").unwrap_or_default();
+        let rpc_pass = std::env::var("BITCOIN_RPC_PASS").unwrap_or_default();
+        let _ =
+            generate_blocks_with_retry(client.as_ref(), &rpc_url, &rpc_user, &rpc_pass, 6).await;
+        sleep(Duration::from_secs(2)).await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/taproot-assets/send")
+                .set_json(&send_body)
+                .to_request(),
+        )
+        .await;
+        send_status = resp.status();
+        send_json = test::read_body_json(resp).await;
+    }
+
+    assert_status_matches_body(send_status, &send_json);
+    assert!(
+        send_status.is_success(),
+        "send must succeed: {send_status} {send_json}"
+    );
 
     // Step 3: List transfers
     let list_resp = test::call_service(


### PR DESCRIPTION
**A failed asset send reported `200 OK`.** A client could not tell a successful send from a rejected one.

`send_assets` relayed tapd's response body verbatim without inspecting its status. v0.3.0 fixed this class of bug across the codebase, but the sweep matched `.json::<T>()` and `src/api/send.rs` used `response.json()` with no turbofish, so the whole file was skipped.

Reproduced against the released v0.3.2 binary:

```
$ curl -X POST -d '{"tap_addrs":[]}' .../v1/taproot-assets/send
gateway HTTP: 200
body: {"code":2,"message":"at least one addr is required, ..."}

$ curl -X POST -d '{"tap_addrs":[]}' https://tapd/v1/taproot-assets/send
tapd HTTP: 500
```

## Change

`send_assets`, `list_assets` and `list_addresses` now go through `parse_upstream`. Those were the only three handlers left that call `.send()` without checking the upstream status; the audit is in the commit and now returns clean.

`list_assets` and `list_addresses` were less severe: they deserialize into concrete types, so a tapd error surfaced as `500 Invalid JSON format` rather than the real status and message.

## Tests

- `test_failed_send_does_not_report_success` asserts a send with no addresses is rejected. Mutation-tested: reverting the fix makes it fail.
- `test_send_validation_errors` asserted `is_success() || is_client_error()` and so passed while tapd returned 500. It now asserts both an empty and a malformed address are rejected.
- `test_complete_transfer_workflow` asserted `send_resp.status().is_success()` and passed only because the `200` hid the failure. It now retries once after confirming pending transfers, since a send needs confirmed coins to anchor with, and mines only on a funding failure so sibling tests' UTXO state is left alone.

## Results

Full integration suite against tapd 0.8.0, `stop_daemon` excluded:

| | passed | failed |
| --- | --- | --- |
| v0.3.2 | 192 | 11 |
| this branch | **195** | **9** |

Three fixed. Unit tests 93/93. `fmt` and `clippy --all-targets -D warnings` pass.

The suite's totals wobble by a few between runs: a handful of funding-dependent tests (`test_psbt_with_specific_inputs`, `test_seal_mint_transaction`, `test_complete_asset_lifecycle`) pass in isolation but depend on wallet state that sibling suites lease and spend. That is pre-existing and unrelated to this change; ~0.5 BTC sits locked by leases after a full run. Tracked in #19.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of upstream API responses and error propagation.
  * Failed asset sends now correctly return an error status instead of being reported as successful responses.
  * Invalid or empty transfer destinations are rejected consistently.

* **Tests**
  * Added regression coverage for unsuccessful send requests.
  * Improved transfer workflow testing, including recovery from temporary funding failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->