### PR TITLE
bump version to v0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "taproot-assets-rest-gateway"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taproot-assets-rest-gateway"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "REST API proxy for Lightning Labs' Taproot Assets"
 readme = "README.md"


### PR DESCRIPTION
Patch release for the upstream-error fix merged in #23.

`send_assets` relayed tapd's response without inspecting its status, so a failed asset send returned `200 OK` with an error body. A client could not tell a successful send from a rejected one. `list_assets` and `list_addresses` had the same gap, surfacing tapd errors as `500 Invalid JSON format`.

Verified against a live tapd 0.8.0 node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->