### PR TITLE
Validate path parameters before proxying to tapd

### DIFF
--- a/src/api/assets.rs
+++ b/src/api/assets.rs
@@ -1,4 +1,4 @@
-use super::{handle_result, parse_upstream, with_query};
+use super::{handle_result, parse_upstream, validate_hex_param, with_query};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpRequest, HttpResponse};
@@ -513,6 +513,9 @@ async fn meta_handler(
     path: web::Path<String>,
 ) -> HttpResponse {
     let asset_id = path.into_inner();
+    if let Err(e) = validate_hex_param(&asset_id) {
+        return handle_result::<serde_json::Value>(Err(e));
+    }
     handle_result(
         get_meta(
             client.as_ref(),
@@ -533,6 +536,9 @@ async fn mint_batches_handler(
     path: web::Path<String>,
 ) -> HttpResponse {
     let batch_key = path.into_inner();
+    if let Err(e) = validate_hex_param(&batch_key) {
+        return handle_result::<serde_json::Value>(Err(e));
+    }
     handle_result(
         get_mint_batches(
             client.as_ref(),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -172,6 +172,15 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_hex_param_rejects_non_hex_and_traversal() {
+        assert!(validate_hex_param(&hex_of(64)).is_ok());
+        assert!(validate_hex_param("invalid_asset_id_123").is_err());
+        assert!(validate_hex_param("../../etc/passwd").is_err());
+        assert!(validate_hex_param("..%2f..%2fgetinfo").is_err());
+        assert!(validate_hex_param("").is_err());
+    }
+
+    #[test]
     fn test_with_query_appends_and_preserves() {
         let base = "https://host/v1/taproot-assets/burns".to_string();
         assert_eq!(with_query(base.clone(), ""), base);

--- a/src/api/rfq.rs
+++ b/src/api/rfq.rs
@@ -1,4 +1,4 @@
-use super::{handle_result, parse_upstream};
+use super::{handle_result, parse_upstream, validate_hex_param};
 use crate::error::AppError;
 use crate::types::{BaseUrl, MacaroonHex};
 use actix_web::{web, HttpRequest, HttpResponse, Result as ActixResult};
@@ -162,6 +162,9 @@ async fn buy_offer_handler(
     req: web::Json<BuyOfferRequest>,
 ) -> HttpResponse {
     let asset_id = path.into_inner();
+    if let Err(e) = validate_hex_param(&asset_id) {
+        return handle_result::<serde_json::Value>(Err(e));
+    }
     handle_result(
         buy_offer(
             client.as_ref(),
@@ -182,6 +185,9 @@ async fn buy_order_handler(
     req: web::Json<BuyOrderRequest>,
 ) -> HttpResponse {
     let asset_id = path.into_inner();
+    if let Err(e) = validate_hex_param(&asset_id) {
+        return handle_result::<serde_json::Value>(Err(e));
+    }
     handle_result(
         buy_order(
             client.as_ref(),
@@ -376,6 +382,9 @@ async fn sell_offer_handler(
     req: web::Json<SellOfferRequest>,
 ) -> HttpResponse {
     let asset_id = path.into_inner();
+    if let Err(e) = validate_hex_param(&asset_id) {
+        return handle_result::<serde_json::Value>(Err(e));
+    }
     handle_result(
         sell_offer(
             client.as_ref(),
@@ -396,6 +405,9 @@ async fn sell_order_handler(
     req: web::Json<SellOrderRequest>,
 ) -> HttpResponse {
     let asset_id = path.into_inner();
+    if let Err(e) = validate_hex_param(&asset_id) {
+        return handle_result::<serde_json::Value>(Err(e));
+    }
     handle_result(
         sell_order(
             client.as_ref(),

--- a/tests/error_handling.rs
+++ b/tests/error_handling.rs
@@ -27,12 +27,11 @@ async fn test_invalid_asset_id_handling() {
         ))
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_client_error() || resp.status().is_success());
-
-    if resp.status().is_success() {
-        let json: Value = test::read_body_json(resp).await;
-        assert!(json.get("error").is_some() || json.get("code").is_some());
-    }
+    assert!(
+        resp.status().is_client_error(),
+        "a non-hex asset id must be rejected, got {}",
+        resp.status()
+    );
 }
 
 #[actix_rt::test]
@@ -287,7 +286,11 @@ async fn test_invalid_hex_encoding() {
         ))
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_client_error() || resp.status().is_success());
+    assert!(
+        resp.status().is_client_error(),
+        "invalid hex must be rejected, got {}",
+        resp.status()
+    );
 }
 
 #[actix_rt::test]
@@ -316,5 +319,36 @@ async fn test_missing_required_fields() {
     if resp.status().is_success() {
         let json: Value = test::read_body_json(resp).await;
         assert!(json.get("error").is_some() || json.get("code").is_some());
+    }
+}
+
+/// Regression test: several handlers interpolated an unvalidated path parameter
+/// into the upstream URL, so invalid input reached tapd as a 500 instead of
+/// being rejected. `validate_hex_param` is also what blocks path traversal.
+#[actix_rt::test]
+#[serial]
+async fn test_path_params_are_validated() {
+    let (client, base_url, macaroon_hex, _) = setup().await;
+    let app = test::init_service(
+        App::new()
+            .app_data(client.clone())
+            .app_data(base_url.clone())
+            .app_data(macaroon_hex.clone())
+            .configure(configure),
+    )
+    .await;
+
+    let bad_paths = [
+        "/v1/taproot-assets/assets/meta/asset-id/not_hex_123",
+        "/v1/taproot-assets/assets/mint/batches/not_hex_123",
+    ];
+    for uri in bad_paths {
+        let req = test::TestRequest::get().uri(uri).to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            actix_web::http::StatusCode::BAD_REQUEST,
+            "{uri} should be rejected with 400"
+        );
     }
 }


### PR DESCRIPTION
Six handlers interpolated a caller-supplied path parameter into the upstream tapd URL without validating it. The universe and wallet handlers already validate theirs; these did not.

- `src/api/assets.rs`: `meta_handler`, `mint_batches_handler`
- `src/api/rfq.rs`: `buy_offer_handler`, `buy_order_handler`, `sell_offer_handler`, `sell_order_handler`

## Impact

**Defense in depth.** `validate_hex_param` is what rejects `/`, `..`, and percent-encoded traversal sequences. Traversal is currently blocked further downstream by actix routing and reqwest URL normalization (a traversal attempt returns 404, not a crafted upstream request), so this is not a live SSRF. But the guard belongs at the trust boundary, consistent with every other path handler, rather than relying on two layers of incidental normalization.

**Error quality.** Invalid input reached tapd and came back as a `500`, e.g. `GET /assets/meta/asset-id/not_hex` returned `500 asset ID must be 32 bytes`. It now returns a `400` from the gateway before any upstream call.

Verified against a live tapd 0.8.0 node: `not_hex` → 400, a valid 64-hex id still passes through (500 only because the asset does not exist, which is correct).

## Change

Each handler now calls `validate_hex_param` on its path parameter and returns the validation error before proxying, matching `keys_handler`, `get_script_key_handler` and the rest. An audit of every `web::Path` handler now shows zero unvalidated ones.

## Tests

- `test_validate_hex_param_rejects_non_hex_and_traversal` (unit, runs in CI) covers non-hex and traversal input.
- `test_path_params_are_validated` (integration) asserts `meta` and `mint/batches` reject a non-hex id with 400. Mutation-tested: removing one validation makes it fail.
- `test_invalid_asset_id_handling` and `test_invalid_hex_encoding` asserted `is_client_error() || is_success()` and so passed while the gateway returned 500. They now assert a client error.

## Results

Full integration suite against tapd 0.8.0, `stop_daemon` excluded: **200 passed / 5 failed**, up from 195/9 on v0.3.3. The four fixed here are the two path-validation tests plus the two stale error-path assertions. Unit tests 93 → 94. `fmt` and `clippy --all-targets -D warnings` pass.

The 5 remaining failures are test-quality issues, not gateway bugs: one sends a proof courier address with no URI scheme (tapd correctly rejects it), and the rest are the funding/UTXO-lease-dependent tests tracked in #19.
