### PR TITLE
bump version to v0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "taproot-assets-rest-gateway"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taproot-assets-rest-gateway"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 description = "REST API proxy for Lightning Labs' Taproot Assets"
 readme = "README.md"


### PR DESCRIPTION
Patch release for the path-parameter validation fix merged in #25.

Six handlers (`assets/meta`, `assets/mint/batches`, and the four RFQ offer/order endpoints) interpolated a caller-supplied path parameter into the upstream tapd URL without validating it. Invalid input reached tapd as a 500; `validate_hex_param` (which also rejects path-traversal sequences) is now applied at the boundary, consistent with the universe and wallet handlers.

Not a live SSRF (traversal is blocked downstream), but a defense-in-depth gap closed. Verified against a live tapd 0.8.0 node.