### PR TITLE
Drop the nightly schedule and fix a flaky psbt test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,10 +1,8 @@
 name: Integration
 
 # The integration suite needs a live bitcoind + lnd + tapd stack, so it is not
-# part of the per-PR checks. It runs nightly and can be triggered by hand.
+# part of the per-PR checks. Trigger it by hand from the Actions tab.
 on:
-  schedule:
-    - cron: "0 6 * * *"
   workflow_dispatch:
 
 env:

--- a/tests/psbt.rs
+++ b/tests/psbt.rs
@@ -534,71 +534,68 @@ async fn test_psbt_with_specific_inputs() {
     .await;
     let utxos_json: Value = test::read_body_json(utxos_resp).await;
 
-    if let Some(managed_utxos) = utxos_json["managed_utxos"].as_object() {
-        if let Some((_, utxo_data)) = managed_utxos.iter().next() {
-            if let Some(assets) = utxo_data["assets"].as_array() {
-                if let Some(asset) = assets
-                    .iter()
-                    .find(|a| a["asset_genesis"]["asset_id"].as_str() == Some(&asset_id))
-                {
-                    let outpoint = utxo_data["outpoint"].as_str().unwrap();
-                    let parts: Vec<&str> = outpoint.split(':').collect();
-                    if parts.len() == 2 {
-                        let script_key = asset["script_key"].as_str().unwrap();
+    // Find any managed UTXO that holds this asset and exposes the fields we need.
+    // Missing fields or no matching UTXO means there is nothing to exercise, so
+    // skip rather than panic on an unwrap.
+    let suitable = utxos_json["managed_utxos"].as_object().and_then(|utxos| {
+        utxos.values().find_map(|utxo_data| {
+            let outpoint = utxo_data["outpoint"].as_str()?;
+            let asset = utxo_data["assets"]
+                .as_array()?
+                .iter()
+                .find(|a| a["asset_genesis"]["asset_id"].as_str() == Some(&asset_id))?;
+            let script_key = asset["script_key"].as_str()?;
+            let (txid, vout) = outpoint.split_once(':')?;
+            Some((
+                txid.to_string(),
+                vout.parse::<u32>().ok()?,
+                script_key.to_string(),
+            ))
+        })
+    });
 
-                        let addr_resp = test::call_service(
-                            &app,
-                            test::TestRequest::post()
-                                .uri("/v1/taproot-assets/addrs")
-                                .set_json(json!({
-                                    "asset_id": asset_id,
-                                    "amt": "10"
-                                }))
-                                .to_request(),
-                        )
-                        .await;
-                        let addr_json: Value = test::read_body_json(addr_resp).await;
-                        let tap_addr = addr_json["encoded"].as_str().unwrap();
+    if let Some((txid, vout, script_key)) = suitable {
+        let addr_resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/taproot-assets/addrs")
+                .set_json(json!({
+                    "asset_id": asset_id,
+                    "amt": "10"
+                }))
+                .to_request(),
+        )
+        .await;
+        let addr_json: Value = test::read_body_json(addr_resp).await;
 
-                        // Try to use specific input
-                        let request = VirtualPsbtFundRequest {
-                            psbt: "".to_string(),
-                            raw: json!({
-                                "inputs": [{
-                                    "outpoint": {
-                                        "txid": txid_to_internal_hex(parts[0]),
-                                        "output_index": parts[1].parse::<u32>().unwrap_or(0)
-                                    },
-                                    "id": asset_id,
-                                    "script_key": script_key
-                                }],
-                                "recipients": {
-                                    tap_addr: 10
-                                }
-                            }),
-                            coin_select_type: "COIN_SELECT_DEFAULT".to_string(),
-                        };
-
-                        let req = test::TestRequest::post()
-                            .uri("/v1/taproot-assets/wallet/virtual-psbt/fund")
-                            .set_json(&request)
-                            .to_request();
-                        let resp = test::call_service(&app, req).await;
-                        let resp_status = resp.status();
-
-                        let json: Value = test::read_body_json(resp).await;
-                        assert_status_matches_body(resp_status, &json);
-                        println!(
-                            "Fund with specific input result: {}",
-                            if json.get("error").is_some() {
-                                "error"
-                            } else {
-                                "success"
-                            }
-                        );
+        if let Some(tap_addr) = addr_json["encoded"].as_str() {
+            let request = VirtualPsbtFundRequest {
+                psbt: "".to_string(),
+                raw: json!({
+                    "inputs": [{
+                        "outpoint": {
+                            "txid": txid_to_internal_hex(&txid),
+                            "output_index": vout
+                        },
+                        "id": asset_id,
+                        "script_key": script_key
+                    }],
+                    "recipients": {
+                        tap_addr: 10
                     }
-                }
-            }
+                }),
+                coin_select_type: "COIN_SELECT_DEFAULT".to_string(),
+            };
+
+            let req = test::TestRequest::post()
+                .uri("/v1/taproot-assets/wallet/virtual-psbt/fund")
+                .set_json(&request)
+                .to_request();
+            let resp = test::call_service(&app, req).await;
+            let resp_status = resp.status();
+
+            let json: Value = test::read_body_json(resp).await;
+            assert_status_matches_body(resp_status, &json);
         }
     }
 }


### PR DESCRIPTION
Two changes, prompted by the nightly Integration run failing (run 29144534991).

## Remove the nightly schedule

The `Integration` workflow was set to run on a `0 6 * * *` cron. That is not wanted: it runs a several-minute stack build and leaves a red run on `main` when a test is flaky, with no one having asked for it. The workflow now triggers only via `workflow_dispatch`, so it runs when you kick it off from the Actions tab.

## Fix the flaky test the nightly caught

The nightly failed on one test: `test_psbt_with_specific_inputs`, panicking with `Option::unwrap() on a None value`.

The test grabbed the *first* managed UTXO and called `.unwrap()` on its `outpoint` and `script_key`. Whether a matched UTXO exposes those fields, and which UTXO iterates first, depends on wallet state, so the unwrap panicked intermittently. The surrounding block was already best-effort (nested `if let`s that skip when no suitable UTXO exists), so the unwraps were the wrong tool.

It now iterates every managed UTXO with `find_map` and `?` guards, selecting one that holds the asset and has a parseable outpoint and script key, and skips cleanly if none qualifies. It cannot panic regardless of wallet state.

Validated against a fresh stack via `itest/run.sh --test psbt`: all 10 psbt tests pass, exit 0.
